### PR TITLE
feat(products): add operation_limits to product_info_limit response (v4) — 0.85.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ozonapi-async"
-version = "0.84.1"
+version = "0.85.0"
 description = "Асинхронный pydantic-интерфейс для Ozon Seller API c ограничением запросов и docstrings"
 readme = "readme.md"
 keywords = [

--- a/src/ozonapi/__init__.py
+++ b/src/ozonapi/__init__.py
@@ -37,7 +37,7 @@ from .infrastructure.logging import ozonapi_logger as logger
 from .seller import SellerAPI, SellerAPIConfig
 
 
-__version__ = "0.84.1"
+__version__ = "0.85.0"
 __author__ = "Alexander Ulianov"
 __email__ = "a.v.ulianov@mail.ru"
 __repository__ = "https://github.com/a-ulianov/OzonAPI"

--- a/src/ozonapi/seller/schemas/products/__init__.py
+++ b/src/ozonapi/seller/schemas/products/__init__.py
@@ -42,6 +42,7 @@ __all__ = [
     "ProductInfoDescriptionRequest",
     "ProductInfoDescriptionResponse",
     "ProductInfoLimitResponse",
+    "ProductInfoLimitOperationLimits",
     "ProductInfoListRequest",
     "ProductInfoListResponse",
     "ProductInfoListItem",
@@ -189,7 +190,10 @@ from .v3__product_list import (
     ProductListResponseResult,
     ProductListQuants,
 )
-from .v4__product_info_limit import ProductInfoLimitResponse
+from .v4__product_info_limit import (
+    ProductInfoLimitOperationLimits,
+    ProductInfoLimitResponse,
+)
 from .v4__product_info_attributes import (
     ProductInfoAttributesResponse,
     ProductInfoAttributesRequest,

--- a/src/ozonapi/seller/schemas/products/v4__product_info_limit.py
+++ b/src/ozonapi/seller/schemas/products/v4__product_info_limit.py
@@ -1,5 +1,6 @@
 """https://docs.ozon.ru/api/seller/?__rr=1#operation/ProductAPI_GetUploadQuota"""
 import datetime
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -57,12 +58,29 @@ class ProductInfoLimitTotal(BaseModel):
     )
 
 
+class ProductInfoLimitOperationLimits(BaseModel):
+    """Доступный лимит на работу с товарами (поминутный).
+
+    Attributes:
+        limit: Количество товаров, которое можно создать за минуту
+        limit_type: Тип текущего лимита (UNSPECIFIED — не указан, RATE_LIMIT_PER_MINUTE — поминутный лимит)
+    """
+    limit: Optional[int] = Field(
+        None, description="Количество товаров, которое можно создать за минуту."
+    )
+    limit_type: Optional[str] = Field(
+        None,
+        description="Тип текущего лимита: UNSPECIFIED — не указан; RATE_LIMIT_PER_MINUTE — поминутный лимит."
+    )
+
+
 class ProductInfoLimitResponse(BaseModel):
     """Описывает схему ответа на запрос об установленных и доступных лимитах на ассортимент, создание и обновление товаров.
 
     Attributes:
         daily_create: Суточный лимит на создание товаров
         daily_update: Суточный лимит на обновление товаров
+        operation_limits: Доступный лимит на работу с товарами (поминутный)
         total: Лимит на ассортимент
     """
     daily_create: ProductInfoLimitDailyCreate = Field(
@@ -70,6 +88,9 @@ class ProductInfoLimitResponse(BaseModel):
     )
     daily_update: ProductInfoLimitDailyUpdate = Field(
         ..., description="Суточный лимит на обновление товаров."
+    )
+    operation_limits: Optional[ProductInfoLimitOperationLimits] = Field(
+        None, description="Доступный лимит на работу с товарами (поминутный)."
     )
     total: ProductInfoLimitTotal = Field(
         ..., description="Лимит на ассортимент."

--- a/tests/test_methods/test_products/test_product_info_limit.py
+++ b/tests/test_methods/test_products/test_product_info_limit.py
@@ -20,6 +20,10 @@ class TestProductInfoLimit:
                 "reset_at": "2024-01-01T00:00:00Z",
                 "usage": 300
             },
+            "operation_limits": {
+                "limit": 100,
+                "limit_type": "RATE_LIMIT_PER_MINUTE"
+            },
             "total": {
                 "limit": 10000,
                 "usage": 2500
@@ -40,5 +44,8 @@ class TestProductInfoLimit:
         assert response.daily_create.usage == 150
         assert response.daily_update.limit == 2000
         assert response.daily_update.usage == 300
+        assert response.operation_limits is not None
+        assert response.operation_limits.limit == 100
+        assert response.operation_limits.limit_type == "RATE_LIMIT_PER_MINUTE"
         assert response.total.limit == 10000
         assert response.total.usage == 2500


### PR DESCRIPTION
## Что изменено
Ozon добавил в ответ `POST /v4/product/info/limit` новый объект **`operation_limits`** — поминутный лимит на создание товаров (сигнал из live-spec, brief 2026-06-10).

- Новая модель `ProductInfoLimitOperationLimits { limit: int, limit_type: str }`.
  `limit_type` типизирован как открытое множество `str` (значения `UNSPECIFIED` | `RATE_LIMIT_PER_MINUTE`) — нельзя live-верифицировать без ключей, защищаемся от появления новых значений.
- В `ProductInfoLimitResponse` добавлено опциональное поле `operation_limits` (аддитивно, обратно совместимо; `None`, если отсутствует).
- Модель ре-экспортирована из `schemas/products/__init__.py`; расширен юнит-тест.

## Почему
Аддитивное непрерывающее изменение сигнатуры реализованного метода — приводим схему в соответствие с live OpenAPI.

## Версия
`0.84.1 → 0.85.0` (minor, новое поле/модель) в `pyproject.toml` и `src/ozonapi/__init__.py`.

## Проверки (локально)
- `pytest`: **565 passed**
- `mypy --config-file .claude/linters/mypy.ini` по изменённому файлу: clean (0 net-new)
- CI по `main` запускается на этом PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
