### PR TITLE
docs(chats): mark /v2/chat/list removed from Ozon spec (2026-06-10) — 0.85.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ozonapi-async"
-version = "0.84.1"
+version = "0.85.1"
 description = "Асинхронный pydantic-интерфейс для Ozon Seller API c ограничением запросов и docstrings"
 readme = "readme.md"
 keywords = [

--- a/readme.md
+++ b/readme.md
@@ -831,7 +831,7 @@ pytest --cov=ozonapi --cov-report=html
 | ✓ | Адрес метода Ozon | Описание метода | Python-метод |
 |---|---|---|---|
 | ✓ | `/v1/chat/send/file` | Отправить файл | `chat_send_file()` |
-| ✓ | `/v2/chat/list` | Список чатов (устарел, 404) | `chat_list_v2()` |
+| ✓ | `/v2/chat/list` | Список чатов (устарел, удалён из спецификации Ozon 2026-06-10, 404 → используйте `chat_list()` v3) | `chat_list_v2()` |
 | ✓ | `/v3/chat/list` | Список чатов | `chat_list()` |
 | ✓ | `/v3/chat/history` | История чата | `chat_history()` |
 </details>

--- a/src/ozonapi/__init__.py
+++ b/src/ozonapi/__init__.py
@@ -37,7 +37,7 @@ from .infrastructure.logging import ozonapi_logger as logger
 from .seller import SellerAPI, SellerAPIConfig
 
 
-__version__ = "0.84.1"
+__version__ = "0.85.1"
 __author__ = "Alexander Ulianov"
 __email__ = "a.v.ulianov@mail.ru"
 __repository__ = "https://github.com/a-ulianov/OzonAPI"

--- a/src/ozonapi/seller/methods/chats/chat_list_v2.py
+++ b/src/ozonapi/seller/methods/chats/chat_list_v2.py
@@ -17,8 +17,11 @@ class ChatListV2Mixin(APIManager):
         Notes:
             • Постраничная выдача через `limit`/`offset`. Элементы чатов плоские
               (без вложенного объекта `chat`).
-            • Устарел: на стороне Ozon endpoint возвращает 404 — используйте
-              `chat_list()` (v3). Метод сохранён для совместимости.
+            • УСТАРЕЛ И УДАЛЁН ИЗ СПЕЦИФИКАЦИИ: с 2026-06-10 операция
+              `/v2/chat/list` исключена из OpenAPI-спецификации Ozon Seller API;
+              на стороне Ozon endpoint возвращает 404. Используйте `chat_list()`
+              (v3). Метод сохранён в библиотеке для обратной совместимости и будет
+              удалён в одном из будущих мажорных релизов.
 
         References:
             https://docs.ozon.ru/api/seller/#operation/ChatAPI_ChatListV2


### PR DESCRIPTION
## Что изменено
Ozon исключил устаревшую операцию **`POST /v2/chat/list`** из опубликованной OpenAPI-спецификации Ozon Seller API (live-spec дельта, brief 2026-06-10).

- Метод и ранее возвращал 404 и был помечен как устаревший. Здесь зафиксирован сам факт удаления из спецификации и усилена рекомендация миграции на `chat_list()` (v3).
- Обновлён docstring `chat_list_v2()` (блок `Notes`) и строка README-каталога.

## Почему НЕ удаляю метод
Опубликованный `chat_list_v2()` **сохранён** для обратной совместимости — его удаление было бы ломающим изменением публичной поверхности для уже установленных зависимостей. Это релизная политика — решение за человеком (эскалация в дайджесте).

## Версия
`0.84.1 → 0.85.1` (patch, docs-only) в `pyproject.toml` и `src/ozonapi/__init__.py`.

> ⚠️ Порядок merge: смержить ПОСЛЕ PR #4 (0.85.0). Ветка отрезана от `main` (0.84.1) и поднимает версию до 0.85.1 в расчёте лечь поверх 0.85.0 — при merge вторым строку версии нужно оставить `0.85.1`.

## Проверки (локально)
- `pytest`: **565 passed**
- README-каталог без изменений счётчиков: `447 / 447`, `grep -c '| ☐ |'` = 0
- CI по `main` запускается на этом PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
