### PR TITLE
feat(fbo): add FBOTransport group — transport cargoes (14 methods) — 0.86.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ozonapi-async"
-version = "0.85.1"
+version = "0.86.0"
 description = "Асинхронный pydantic-интерфейс для Ozon Seller API c ограничением запросов и docstrings"
 readme = "readme.md"
 keywords = [

--- a/readme.md
+++ b/readme.md
@@ -410,7 +410,7 @@ pytest --cov=ozonapi --cov-report=html
 
 ## ✔️ Реализованные методы Ozon Seller API
 
-**Реализовано методов: 447 / 447**
+**Реализовано методов: 461 / 461**
 
 <details>
 <summary>Информация по API-ключу (1/1)</summary>
@@ -665,7 +665,7 @@ pytest --cov=ozonapi --cov-report=html
 | ✓ | `/v1/supplier/available_warehouses` | Загруженность складов Ozon | `supplier_available_warehouses()` |
 </details>
 <details>
-<summary>Создание и управление заявками на поставку FBO (29/29)</summary>
+<summary>Создание и управление заявками на поставку FBO (43/43)</summary>
 
 | ✓ | Адрес метода Ozon | Описание метода | Python-метод |
 |---|---|---|---|
@@ -683,13 +683,27 @@ pytest --cov=ozonapi --cov-report=html
 | ✓ | `/v2/draft/timeslot/info` | Получить список доступных таймслотов | `draft_timeslot_info()` |
 | ✓ | `/v1/cargoes/create` | Установка грузомест | `cargoes_create()` |
 | ✓ | `/v2/cargoes/create/info` | Получить информацию по установке грузомест | `cargoes_create_info()` |
-| ✓ | `/v1/cargoes/get` | Получить информацию о грузоместах | `cargoes_get()` |
-| ✓ | `/v1/cargoes/delete` | Удалить грузоместо в заявке на поставку | `cargoes_delete()` |
-| ✓ | `/v1/cargoes/delete/status` | Информация о статусе удаления грузоместа | `cargoes_delete_status()` |
+| ✓ | `/v1/cargoes/get` | Получить информацию о грузоместах ⚠️ устар. → `cargoes_get()` | `cargoes_get_v1()` |
+| ✓ | `/v2/cargoes/get` | Получить информацию о грузоместах | `cargoes_get()` |
+| ✓ | `/v1/cargoes/delete` | Удалить грузоместо в заявке на поставку ⚠️ устар. → `cargoes_delete()` | `cargoes_delete_v1()` |
+| ✓ | `/v1/cargoes/delete/status` | Информация о статусе удаления грузоместа ⚠️ устар. → `cargoes_delete_status()` | `cargoes_delete_status_v1()` |
+| ✓ | `/v2/cargoes/delete` | Удалить грузоместа и транспортные грузоместа в заявке на поставку | `cargoes_delete()` |
+| ✓ | `/v2/cargoes/delete/status` | Получить информацию о статусе удаления грузомест и транспортных грузомест | `cargoes_delete_status()` |
 | ✓ | `/v1/cargoes/rules/get` | Чек-лист по установке грузомест FBO | `cargoes_rules_get()` |
+| ✓ | `/v1/cargoes/supplies/get` | Получить информацию о грузоместах в поставках | `cargoes_supplies_get()` |
+| ✓ | `/v1/cargoes/transport/create` | Создать транспортное грузоместо | `cargoes_transport_create()` |
+| ✓ | `/v1/cargoes/transport/create/status` | Получить статус создания транспортного грузоместа | `cargoes_transport_create_status()` |
+| ✓ | `/v1/cargoes/transport/activate` | Включить или отключить транспортные грузоместа в поставке | `cargoes_transport_activate()` |
+| ✓ | `/v1/cargoes/transport/activate/status` | Получить статус включения или отключения транспортных грузомест | `cargoes_transport_activate_status()` |
+| ✓ | `/v1/cargoes/transport/bind` | Связать или отвязать грузоместа и транспортные грузоместа | `cargoes_transport_bind()` |
+| ✓ | `/v1/cargoes/transport/bind/status` | Получить статус связывания или отвязывания грузомест и транспортных грузомест | `cargoes_transport_bind_status()` |
 | ✓ | `/v1/cargoes-label/create` | Сгенерировать этикетки для грузомест | `cargoes_label_create()` |
 | ✓ | `/v1/cargoes-label/get` | Получить идентификатор этикетки для грузомест | `cargoes_label_get()` |
 | ✓ | `/v1/cargoes-label/file/{file_guid}` | Получить PDF с этикетками грузовых мест | `cargoes_label_file()` |
+| ✓ | `/v1/cargoes/label/transport/create` | Сгенерировать этикетки транспортных грузомест по идентификатору грузоместа | `cargoes_label_transport_create()` |
+| ✓ | `/v1/cargoes/label/transport/status` | Получить статус генерации этикеток транспортных грузомест по идентификатору грузоместа | `cargoes_label_transport_status()` |
+| ✓ | `/v1/cargoes/label/transport-by-order/create` | Сгенерировать этикетки для транспортных грузомест по идентификатору поставки | `cargoes_label_transport_by_order_create()` |
+| ✓ | `/v1/cargoes/label/transport-by-order/status` | Получить статус генерации этикеток для транспортных грузомест по идентификатору поставки | `cargoes_label_transport_by_order_status()` |
 | ✓ | `/v1/supply-order/cancel` | Отменить заявку на поставку | `supply_order_cancel()` |
 | ✓ | `/v1/supply-order/cancel/status` | Получить статус отмены заявки на поставку | `supply_order_cancel_status()` |
 | ✓ | `/v1/supply-order/content/update` | Редактирование товарного состава | `supply_order_content_update()` |

--- a/src/ozonapi/__init__.py
+++ b/src/ozonapi/__init__.py
@@ -35,7 +35,7 @@ Examples:
 from .infrastructure import logging
 from .infrastructure.logging import ozonapi_logger as logger
 from .seller import SellerAPI, SellerAPIConfig
-__version__ = "0.85.1"
+__version__ = "0.86.0"
 __author__ = "Alexander Ulianov"
 __email__ = "a.v.ulianov@mail.ru"
 __repository__ = "https://github.com/a-ulianov/OzonAPI"

--- a/src/ozonapi/seller/methods/fbo_supply_request/__init__.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/__init__.py
@@ -9,11 +9,31 @@ from .cargoes_create import CargoesCreateMixin
 from .cargoes_create_info import CargoesCreateInfoMixin
 from .cargoes_delete import CargoesDeleteMixin
 from .cargoes_delete_status import CargoesDeleteStatusMixin
+from .cargoes_delete_status_v1 import CargoesDeleteStatusV1Mixin
+from .cargoes_delete_v1 import CargoesDeleteV1Mixin
 from .cargoes_get import CargoesGetMixin
+from .cargoes_get_v1 import CargoesGetV1Mixin
 from .cargoes_label_create import CargoesLabelCreateMixin
 from .cargoes_label_file import CargoesLabelFileMixin
 from .cargoes_label_get import CargoesLabelGetMixin
+from .cargoes_label_transport_by_order_create import (
+    CargoesLabelTransportByOrderCreateMixin,
+)
+from .cargoes_label_transport_by_order_status import (
+    CargoesLabelTransportByOrderStatusMixin,
+)
+from .cargoes_label_transport_create import CargoesLabelTransportCreateMixin
+from .cargoes_label_transport_status import CargoesLabelTransportStatusMixin
 from .cargoes_rules_get import CargoesRulesGetMixin
+from .cargoes_supplies_get import CargoesSuppliesGetMixin
+from .cargoes_transport_activate import CargoesTransportActivateMixin
+from .cargoes_transport_activate_status import (
+    CargoesTransportActivateStatusMixin,
+)
+from .cargoes_transport_bind import CargoesTransportBindMixin
+from .cargoes_transport_bind_status import CargoesTransportBindStatusMixin
+from .cargoes_transport_create import CargoesTransportCreateMixin
+from .cargoes_transport_create_status import CargoesTransportCreateStatusMixin
 from .cluster_list_v1 import ClusterListV1Mixin
 from .draft_create import DraftCreateMixin
 from .draft_create_info import DraftCreateInfoMixin
@@ -45,11 +65,25 @@ class SellerFboSupplyRequestAPI(
     CargoesCreateInfoMixin,
     CargoesDeleteMixin,
     CargoesDeleteStatusMixin,
+    CargoesDeleteStatusV1Mixin,
+    CargoesDeleteV1Mixin,
     CargoesGetMixin,
+    CargoesGetV1Mixin,
     CargoesLabelCreateMixin,
     CargoesLabelFileMixin,
     CargoesLabelGetMixin,
+    CargoesLabelTransportByOrderCreateMixin,
+    CargoesLabelTransportByOrderStatusMixin,
+    CargoesLabelTransportCreateMixin,
+    CargoesLabelTransportStatusMixin,
     CargoesRulesGetMixin,
+    CargoesSuppliesGetMixin,
+    CargoesTransportActivateMixin,
+    CargoesTransportActivateStatusMixin,
+    CargoesTransportBindMixin,
+    CargoesTransportBindStatusMixin,
+    CargoesTransportCreateMixin,
+    CargoesTransportCreateStatusMixin,
     ClusterListV1Mixin,
     DraftCreateMixin,
     DraftCreateInfoMixin,

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete.py
@@ -6,20 +6,23 @@ from ...schemas.fbo_supply_request import (
 
 
 class CargoesDeleteMixin(APIManager):
-    """Реализует метод /v1/cargoes/delete"""
+    """Реализует метод /v2/cargoes/delete"""
 
     async def cargoes_delete(
             self: "CargoesDeleteMixin",
             request: CargoesDeleteRequest
     ) -> CargoesDeleteResponse:
-        """Запускает удаление грузомест из заявки на поставку FBO.
+        """Запускает удаление грузомест и транспортных грузомест из поставки FBO.
 
         Notes:
-            • Асинхронная операция; статус — через `cargoes_delete_status()`
-              по `operation_id`.
+            • Канонический метод (v2): удаляет как грузоместа, так и транспортные
+              грузоместа; способ удаления задаётся `transport_cargo_deletion_type`.
+              Устаревшая v1-версия доступна как `cargoes_delete_v1()`.
+            • Асинхронная операция; статус — через `cargoes_delete_status()` по
+              `operation_id`.
 
         References:
-            https://docs.ozon.ru/api/seller/#operation/CargoesAPI_CargoesDelete
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
 
         Args:
             request: Запрос удаления грузомест по схеме `CargoesDeleteRequest`
@@ -30,12 +33,16 @@ class CargoesDeleteMixin(APIManager):
         Examples:
             async with SellerAPI(client_id, api_key) as api:
                 result = await api.cargoes_delete(
-                    CargoesDeleteRequest(supply_id=123, cargo_ids=["1"])
+                    CargoesDeleteRequest(
+                        supply_id=123,
+                        cargo_ids=["1"],
+                        transport_cargo_deletion_type="UNBIND_CONTAINED_CARGOES",
+                    )
                 )
         """
         response = await self._request(
             method="post",
-            api_version="v1",
+            api_version="v2",
             endpoint="cargoes/delete",
             payload=request.model_dump(by_alias=True)
         )

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete_status.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete_status.py
@@ -6,22 +6,25 @@ from ...schemas.fbo_supply_request import (
 
 
 class CargoesDeleteStatusMixin(APIManager):
-    """Реализует метод /v1/cargoes/delete/status"""
+    """Реализует метод /v2/cargoes/delete/status"""
 
     async def cargoes_delete_status(
             self: "CargoesDeleteStatusMixin",
             request: CargoesDeleteStatusRequest
     ) -> CargoesDeleteStatusResponse:
-        """Возвращает статус удаления грузомест из заявки на поставку FBO.
+        """Возвращает статус удаления грузомест и транспортных грузомест.
 
         Notes:
+            • Канонический метод (v2). Устаревшая v1-версия доступна как
+              `cargoes_delete_status_v1()`.
             • Используйте `operation_id`, полученный методом `cargoes_delete()`.
 
         References:
-            https://docs.ozon.ru/api/seller/#operation/CargoesAPI_CargoesDeleteStatus
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
 
         Args:
-            request: Запрос статуса удаления по схеме `CargoesDeleteStatusRequest`
+            request: Запрос статуса удаления по схеме
+                `CargoesDeleteStatusRequest`
 
         Returns:
             Статус удаления грузомест по схеме `CargoesDeleteStatusResponse`
@@ -34,7 +37,7 @@ class CargoesDeleteStatusMixin(APIManager):
         """
         response = await self._request(
             method="post",
-            api_version="v1",
+            api_version="v2",
             endpoint="cargoes/delete/status",
             payload=request.model_dump(by_alias=True)
         )

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete_status_v1.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete_status_v1.py
@@ -1,0 +1,45 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesDeleteStatusV1Request,
+    CargoesDeleteStatusV1Response,
+)
+
+
+class CargoesDeleteStatusV1Mixin(APIManager):
+    """Реализует метод /v1/cargoes/delete/status"""
+
+    async def cargoes_delete_status_v1(
+            self: "CargoesDeleteStatusV1Mixin",
+            request: CargoesDeleteStatusV1Request
+    ) -> CargoesDeleteStatusV1Response:
+        """Возвращает статус удаления грузомест из заявки на поставку FBO (v1).
+
+        Notes:
+            • Устаревшая версия. Используйте канонический
+              `cargoes_delete_status()` (v2).
+            • Используйте `operation_id`, полученный методом
+              `cargoes_delete_v1()`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#operation/CargoesAPI_CargoesDeleteStatus
+
+        Args:
+            request: Запрос статуса удаления по схеме
+                `CargoesDeleteStatusV1Request`
+
+        Returns:
+            Статус удаления грузомест по схеме `CargoesDeleteStatusV1Response`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_delete_status_v1(
+                    CargoesDeleteStatusV1Request(operation_id="op-1")
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/delete/status",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesDeleteStatusV1Response(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete_v1.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_delete_v1.py
@@ -1,0 +1,44 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesDeleteV1Request,
+    CargoesDeleteV1Response,
+)
+
+
+class CargoesDeleteV1Mixin(APIManager):
+    """Реализует метод /v1/cargoes/delete"""
+
+    async def cargoes_delete_v1(
+            self: "CargoesDeleteV1Mixin",
+            request: CargoesDeleteV1Request
+    ) -> CargoesDeleteV1Response:
+        """Запускает удаление грузомест из заявки на поставку FBO (v1).
+
+        Notes:
+            • Устаревшая версия. Используйте канонический `cargoes_delete()`
+              (v2), поддерживающий удаление транспортных грузомест.
+            • Асинхронная операция; статус — через `cargoes_delete_status_v1()`
+              по `operation_id`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#operation/CargoesAPI_CargoesDelete
+
+        Args:
+            request: Запрос удаления грузомест по схеме `CargoesDeleteV1Request`
+
+        Returns:
+            Идентификатор операции по схеме `CargoesDeleteV1Response`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_delete_v1(
+                    CargoesDeleteV1Request(supply_id=123, cargo_ids=["1"])
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/delete",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesDeleteV1Response(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_get.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_get.py
@@ -6,7 +6,7 @@ from ...schemas.fbo_supply_request import (
 
 
 class CargoesGetMixin(APIManager):
-    """Реализует метод /v1/cargoes/get"""
+    """Реализует метод /v2/cargoes/get"""
 
     async def cargoes_get(
             self: "CargoesGetMixin",
@@ -15,11 +15,12 @@ class CargoesGetMixin(APIManager):
         """Возвращает информацию о грузоместах в заявках на поставку FBO.
 
         Notes:
-            • Возвращает грузоместа по каждой запрошенной поставке вместе с данными
-              отслеживания и типом зоны размещения.
+            • Канонический метод (v2): дополнительно возвращает транспортные
+              грузоместа, лимиты поставки и данные отслеживания. Устаревшая
+              v1-версия доступна как `cargoes_get_v1()`.
 
         References:
-            https://docs.ozon.ru/api/seller/#operation/CargoesGet
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
 
         Args:
             request: Запрос информации о грузоместах по схеме `CargoesGetRequest`
@@ -30,12 +31,18 @@ class CargoesGetMixin(APIManager):
         Examples:
             async with SellerAPI(client_id, api_key) as api:
                 result = await api.cargoes_get(
-                    CargoesGetRequest(supply_ids=["123"])
+                    CargoesGetRequest(
+                        supplies=[
+                            CargoesGetSupplyRequest(
+                                supply_id=123, cargo_ids=["1"]
+                            )
+                        ]
+                    )
                 )
         """
         response = await self._request(
             method="post",
-            api_version="v1",
+            api_version="v2",
             endpoint="cargoes/get",
             payload=request.model_dump(by_alias=True)
         )

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_get_v1.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_get_v1.py
@@ -1,0 +1,43 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesGetV1Request,
+    CargoesGetV1Response,
+)
+
+
+class CargoesGetV1Mixin(APIManager):
+    """Реализует метод /v1/cargoes/get"""
+
+    async def cargoes_get_v1(
+            self: "CargoesGetV1Mixin",
+            request: CargoesGetV1Request
+    ) -> CargoesGetV1Response:
+        """Возвращает информацию о грузоместах в заявках на поставку FBO (v1).
+
+        Notes:
+            • Устаревшая версия. Используйте канонический `cargoes_get()` (v2),
+              возвращающий данные о транспортных грузоместах и лимитах.
+
+        References:
+            https://docs.ozon.ru/api/seller/#operation/CargoesGet
+
+        Args:
+            request: Запрос информации о грузоместах по схеме
+                `CargoesGetV1Request`
+
+        Returns:
+            Грузоместа поставок по схеме `CargoesGetV1Response`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_get_v1(
+                    CargoesGetV1Request(supply_ids=["123"])
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/get",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesGetV1Response(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_by_order_create.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_by_order_create.py
@@ -1,0 +1,44 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesLabelTransportByOrderCreateRequest,
+    CargoesLabelTransportByOrderCreateResponse,
+)
+
+
+class CargoesLabelTransportByOrderCreateMixin(APIManager):
+    """Реализует метод /v1/cargoes/label/transport-by-order/create"""
+
+    async def cargoes_label_transport_by_order_create(
+            self: "CargoesLabelTransportByOrderCreateMixin",
+            request: CargoesLabelTransportByOrderCreateRequest
+    ) -> CargoesLabelTransportByOrderCreateResponse:
+        """Запускает генерацию этикеток транспортных грузомест по поставке.
+
+        Notes:
+            • Асинхронная операция; статус и ссылку на файл — через
+              `cargoes_label_transport_by_order_status()` по `operation_id`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос генерации этикеток по схеме
+                `CargoesLabelTransportByOrderCreateRequest`
+
+        Returns:
+            Идентификатор операции по схеме
+            `CargoesLabelTransportByOrderCreateResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_label_transport_by_order_create(
+                    CargoesLabelTransportByOrderCreateRequest(order_id=123)
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport-by-order/create",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesLabelTransportByOrderCreateResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_by_order_status.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_by_order_status.py
@@ -1,0 +1,46 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesLabelTransportByOrderStatusRequest,
+    CargoesLabelTransportByOrderStatusResponse,
+)
+
+
+class CargoesLabelTransportByOrderStatusMixin(APIManager):
+    """Реализует метод /v1/cargoes/label/transport-by-order/status"""
+
+    async def cargoes_label_transport_by_order_status(
+            self: "CargoesLabelTransportByOrderStatusMixin",
+            request: CargoesLabelTransportByOrderStatusRequest
+    ) -> CargoesLabelTransportByOrderStatusResponse:
+        """Возвращает статус генерации этикеток транспортных грузомест по поставке.
+
+        Notes:
+            • Используйте `operation_id`, полученный методом
+              `cargoes_label_transport_by_order_create()`. В `result.file_url` —
+              ссылка на файл, в `result.skipped_supplies_ids` — пропущенные
+              поставки.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос статуса генерации по схеме
+                `CargoesLabelTransportByOrderStatusRequest`
+
+        Returns:
+            Статус и ссылку на файл по схеме
+            `CargoesLabelTransportByOrderStatusResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_label_transport_by_order_status(
+                    CargoesLabelTransportByOrderStatusRequest(operation_id="op-1")
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport-by-order/status",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesLabelTransportByOrderStatusResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_create.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_create.py
@@ -1,0 +1,46 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesLabelTransportCreateRequest,
+    CargoesLabelTransportCreateResponse,
+)
+
+
+class CargoesLabelTransportCreateMixin(APIManager):
+    """Реализует метод /v1/cargoes/label/transport/create"""
+
+    async def cargoes_label_transport_create(
+            self: "CargoesLabelTransportCreateMixin",
+            request: CargoesLabelTransportCreateRequest
+    ) -> CargoesLabelTransportCreateResponse:
+        """Запускает генерацию этикеток транспортных грузомест по грузоместу.
+
+        Notes:
+            • Асинхронная операция; статус и ссылку на файл — через
+              `cargoes_label_transport_status()` по `operation_id`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос генерации этикеток по схеме
+                `CargoesLabelTransportCreateRequest`
+
+        Returns:
+            Идентификатор операции по схеме
+            `CargoesLabelTransportCreateResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_label_transport_create(
+                    CargoesLabelTransportCreateRequest(
+                        supply_id=123, transport_cargo_ids=["10"]
+                    )
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport/create",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesLabelTransportCreateResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_status.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_label_transport_status.py
@@ -1,0 +1,45 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesLabelTransportStatusRequest,
+    CargoesLabelTransportStatusResponse,
+)
+
+
+class CargoesLabelTransportStatusMixin(APIManager):
+    """Реализует метод /v1/cargoes/label/transport/status"""
+
+    async def cargoes_label_transport_status(
+            self: "CargoesLabelTransportStatusMixin",
+            request: CargoesLabelTransportStatusRequest
+    ) -> CargoesLabelTransportStatusResponse:
+        """Возвращает статус генерации этикеток транспортных грузомест.
+
+        Notes:
+            • Используйте `operation_id`, полученный методом
+              `cargoes_label_transport_create()`. При успехе в `result.file_url`
+              возвращается ссылка на файл с этикетками.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос статуса генерации по схеме
+                `CargoesLabelTransportStatusRequest`
+
+        Returns:
+            Статус и ссылку на файл по схеме
+            `CargoesLabelTransportStatusResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_label_transport_status(
+                    CargoesLabelTransportStatusRequest(operation_id="op-1")
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport/status",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesLabelTransportStatusResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_supplies_get.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_supplies_get.py
@@ -1,0 +1,43 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesSuppliesGetRequest,
+    CargoesSuppliesGetResponse,
+)
+
+
+class CargoesSuppliesGetMixin(APIManager):
+    """Реализует метод /v1/cargoes/supplies/get"""
+
+    async def cargoes_supplies_get(
+            self: "CargoesSuppliesGetMixin",
+            request: CargoesSuppliesGetRequest
+    ) -> CargoesSuppliesGetResponse:
+        """Возвращает информацию о грузоместах в поставках FBO.
+
+        Notes:
+            • Для каждой поставки возвращаются как грузоместа без транспортных
+              грузомест, так и транспортные грузоместа с их содержимым.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос информации о грузоместах по схеме
+                `CargoesSuppliesGetRequest`
+
+        Returns:
+            Грузоместа по поставкам по схеме `CargoesSuppliesGetResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_supplies_get(
+                    CargoesSuppliesGetRequest(supply_ids=["123"])
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/supplies/get",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesSuppliesGetResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_activate.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_activate.py
@@ -1,0 +1,45 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesTransportActivateRequest,
+    CargoesTransportActivateResponse,
+)
+
+
+class CargoesTransportActivateMixin(APIManager):
+    """Реализует метод /v1/cargoes/transport/activate"""
+
+    async def cargoes_transport_activate(
+            self: "CargoesTransportActivateMixin",
+            request: CargoesTransportActivateRequest
+    ) -> CargoesTransportActivateResponse:
+        """Включает или отключает транспортные грузоместа в поставке FBO.
+
+        Notes:
+            • Асинхронная операция; статус — через
+              `cargoes_transport_activate_status()` по `operation_id`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос включения транспортных грузомест по схеме
+                `CargoesTransportActivateRequest`
+
+        Returns:
+            Идентификатор операции по схеме `CargoesTransportActivateResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_transport_activate(
+                    CargoesTransportActivateRequest(
+                        supply_id=123, is_transport=True
+                    )
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/activate",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesTransportActivateResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_activate_status.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_activate_status.py
@@ -1,0 +1,43 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesTransportActivateStatusRequest,
+    CargoesTransportActivateStatusResponse,
+)
+
+
+class CargoesTransportActivateStatusMixin(APIManager):
+    """Реализует метод /v1/cargoes/transport/activate/status"""
+
+    async def cargoes_transport_activate_status(
+            self: "CargoesTransportActivateStatusMixin",
+            request: CargoesTransportActivateStatusRequest
+    ) -> CargoesTransportActivateStatusResponse:
+        """Возвращает статус включения или отключения транспортных грузомест.
+
+        Notes:
+            • Используйте `operation_id`, полученный методом
+              `cargoes_transport_activate()`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос статуса включения по схеме
+                `CargoesTransportActivateStatusRequest`
+
+        Returns:
+            Статус операции по схеме `CargoesTransportActivateStatusResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_transport_activate_status(
+                    CargoesTransportActivateStatusRequest(operation_id="op-1")
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/activate/status",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesTransportActivateStatusResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_bind.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_bind.py
@@ -1,0 +1,50 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesTransportBindRequest,
+    CargoesTransportBindResponse,
+)
+
+
+class CargoesTransportBindMixin(APIManager):
+    """Реализует метод /v1/cargoes/transport/bind"""
+
+    async def cargoes_transport_bind(
+            self: "CargoesTransportBindMixin",
+            request: CargoesTransportBindRequest
+    ) -> CargoesTransportBindResponse:
+        """Связывает или отвязывает грузоместа и транспортные грузоместа.
+
+        Notes:
+            • Асинхронная операция; статус — через
+              `cargoes_transport_bind_status()` по `operation_id`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос связывания грузомест по схеме
+                `CargoesTransportBindRequest`
+
+        Returns:
+            Идентификатор операции по схеме `CargoesTransportBindResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_transport_bind(
+                    CargoesTransportBindRequest(
+                        supply_id=123,
+                        transport_cargo_bind=[
+                            CargoesTransportBindItem(
+                                cargo_ids=["1"], transport_cargo_id=10
+                            )
+                        ],
+                    )
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/bind",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesTransportBindResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_bind_status.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_bind_status.py
@@ -1,0 +1,43 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesTransportBindStatusRequest,
+    CargoesTransportBindStatusResponse,
+)
+
+
+class CargoesTransportBindStatusMixin(APIManager):
+    """Реализует метод /v1/cargoes/transport/bind/status"""
+
+    async def cargoes_transport_bind_status(
+            self: "CargoesTransportBindStatusMixin",
+            request: CargoesTransportBindStatusRequest
+    ) -> CargoesTransportBindStatusResponse:
+        """Возвращает статус связывания или отвязывания грузомест.
+
+        Notes:
+            • Используйте `operation_id`, полученный методом
+              `cargoes_transport_bind()`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос статуса связывания по схеме
+                `CargoesTransportBindStatusRequest`
+
+        Returns:
+            Статус операции по схеме `CargoesTransportBindStatusResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_transport_bind_status(
+                    CargoesTransportBindStatusRequest(operation_id="op-1")
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/bind/status",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesTransportBindStatusResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_create.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_create.py
@@ -1,0 +1,48 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesTransportCreateRequest,
+    CargoesTransportCreateResponse,
+)
+
+
+class CargoesTransportCreateMixin(APIManager):
+    """Реализует метод /v1/cargoes/transport/create"""
+
+    async def cargoes_transport_create(
+            self: "CargoesTransportCreateMixin",
+            request: CargoesTransportCreateRequest
+    ) -> CargoesTransportCreateResponse:
+        """Создаёт транспортные грузоместа в поставке FBO.
+
+        Notes:
+            • Асинхронная операция; статус — через
+              `cargoes_transport_create_status()` по `operation_id`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос создания транспортных грузомест по схеме
+                `CargoesTransportCreateRequest`
+
+        Returns:
+            Идентификатор операции по схеме `CargoesTransportCreateResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_transport_create(
+                    CargoesTransportCreateRequest(
+                        supply_id=123,
+                        transport_cargoes=[
+                            CargoesTransportCreateItem(count=1, type="PALLET")
+                        ],
+                    )
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/create",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesTransportCreateResponse(**response)

--- a/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_create_status.py
+++ b/src/ozonapi/seller/methods/fbo_supply_request/cargoes_transport_create_status.py
@@ -1,0 +1,43 @@
+from ...core import APIManager
+from ...schemas.fbo_supply_request import (
+    CargoesTransportCreateStatusRequest,
+    CargoesTransportCreateStatusResponse,
+)
+
+
+class CargoesTransportCreateStatusMixin(APIManager):
+    """Реализует метод /v1/cargoes/transport/create/status"""
+
+    async def cargoes_transport_create_status(
+            self: "CargoesTransportCreateStatusMixin",
+            request: CargoesTransportCreateStatusRequest
+    ) -> CargoesTransportCreateStatusResponse:
+        """Возвращает статус создания транспортных грузомест.
+
+        Notes:
+            • Используйте `operation_id`, полученный методом
+              `cargoes_transport_create()`.
+
+        References:
+            https://docs.ozon.ru/api/seller/#tag/FBOTransport
+
+        Args:
+            request: Запрос статуса создания по схеме
+                `CargoesTransportCreateStatusRequest`
+
+        Returns:
+            Статус создания по схеме `CargoesTransportCreateStatusResponse`
+
+        Examples:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.cargoes_transport_create_status(
+                    CargoesTransportCreateStatusRequest(operation_id="op-1")
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/create/status",
+            payload=request.model_dump(by_alias=True)
+        )
+        return CargoesTransportCreateStatusResponse(**response)

--- a/src/ozonapi/seller/schemas/fbo_supply_request/__init__.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/__init__.py
@@ -84,17 +84,67 @@ __all__ = [
     "CargoesCreateInfoCargo",
     "CargoesCreateInfoResult",
     "CargoesCreateInfoResponse",
+    "CargoesGetV1Request",
+    "CargoesGetV1TrackingInfo",
+    "CargoesGetV1Cargo",
+    "CargoesGetV1Supply",
+    "CargoesGetV1Response",
+    "CargoesDeleteV1Request",
+    "CargoesDeleteV1CargoErrorReason",
+    "CargoesDeleteV1Errors",
+    "CargoesDeleteV1Response",
+    "CargoesDeleteStatusV1Request",
+    "CargoesDeleteStatusV1Response",
+    "CargoesGetSupplyRequest",
     "CargoesGetRequest",
+    "CargoesGetTimezone",
+    "CargoesGetArrivalAt",
     "CargoesGetTrackingInfo",
     "CargoesGetCargo",
+    "CargoesGetLimits",
+    "CargoesGetTransportArrivalAt",
+    "CargoesGetTransportTrackingInfo",
+    "CargoesGetTransportCargo",
     "CargoesGetSupply",
     "CargoesGetResponse",
     "CargoesDeleteRequest",
     "CargoesDeleteCargoErrorReason",
+    "CargoesDeleteTransportCargoErrorReason",
     "CargoesDeleteErrors",
     "CargoesDeleteResponse",
     "CargoesDeleteStatusRequest",
     "CargoesDeleteStatusResponse",
+    "CargoesTransportCreateItem",
+    "CargoesTransportCreateRequest",
+    "CargoesTransportCreateResponse",
+    "CargoesTransportCreateStatusRequest",
+    "CargoesTransportCreateStatusTransportCargo",
+    "CargoesTransportCreateStatusResult",
+    "CargoesTransportCreateStatusResponse",
+    "CargoesTransportActivateRequest",
+    "CargoesTransportActivateResponse",
+    "CargoesTransportActivateStatusRequest",
+    "CargoesTransportActivateStatusResponse",
+    "CargoesTransportBindItem",
+    "CargoesTransportBindRequest",
+    "CargoesTransportBindResponse",
+    "CargoesTransportBindStatusRequest",
+    "CargoesTransportBindStatusResponse",
+    "CargoesSuppliesGetRequest",
+    "CargoesSuppliesGetCargo",
+    "CargoesSuppliesGetTransportCargo",
+    "CargoesSuppliesGetSupply",
+    "CargoesSuppliesGetResponse",
+    "CargoesLabelTransportCreateRequest",
+    "CargoesLabelTransportCreateResponse",
+    "CargoesLabelTransportStatusRequest",
+    "CargoesLabelTransportStatusResult",
+    "CargoesLabelTransportStatusResponse",
+    "CargoesLabelTransportByOrderCreateRequest",
+    "CargoesLabelTransportByOrderCreateResponse",
+    "CargoesLabelTransportByOrderStatusRequest",
+    "CargoesLabelTransportByOrderStatusResult",
+    "CargoesLabelTransportByOrderStatusResponse",
     "CargoesRulesGetRequest",
     "CargoesRulesCargoCountPerType",
     "CargoesRulesPresentsRule",
@@ -176,21 +226,99 @@ from .v2__cargoes_create_info import (
     CargoesCreateInfoResult,
 )
 from .v1__cargoes_get import (
+    CargoesGetV1Cargo,
+    CargoesGetV1Request,
+    CargoesGetV1Response,
+    CargoesGetV1Supply,
+    CargoesGetV1TrackingInfo,
+)
+from .v1__cargoes_delete import (
+    CargoesDeleteV1CargoErrorReason,
+    CargoesDeleteV1Errors,
+    CargoesDeleteV1Request,
+    CargoesDeleteV1Response,
+)
+from .v1__cargoes_delete_status import (
+    CargoesDeleteStatusV1Request,
+    CargoesDeleteStatusV1Response,
+)
+from .v2__cargoes_get import (
+    CargoesGetArrivalAt,
     CargoesGetCargo,
+    CargoesGetLimits,
     CargoesGetRequest,
     CargoesGetResponse,
     CargoesGetSupply,
+    CargoesGetSupplyRequest,
+    CargoesGetTimezone,
     CargoesGetTrackingInfo,
+    CargoesGetTransportArrivalAt,
+    CargoesGetTransportCargo,
+    CargoesGetTransportTrackingInfo,
 )
-from .v1__cargoes_delete import (
+from .v2__cargoes_delete import (
     CargoesDeleteCargoErrorReason,
     CargoesDeleteErrors,
     CargoesDeleteRequest,
     CargoesDeleteResponse,
+    CargoesDeleteTransportCargoErrorReason,
 )
-from .v1__cargoes_delete_status import (
+from .v2__cargoes_delete_status import (
     CargoesDeleteStatusRequest,
     CargoesDeleteStatusResponse,
+)
+from .v1__cargoes_transport_create import (
+    CargoesTransportCreateItem,
+    CargoesTransportCreateRequest,
+    CargoesTransportCreateResponse,
+)
+from .v1__cargoes_transport_create_status import (
+    CargoesTransportCreateStatusRequest,
+    CargoesTransportCreateStatusResponse,
+    CargoesTransportCreateStatusResult,
+    CargoesTransportCreateStatusTransportCargo,
+)
+from .v1__cargoes_transport_activate import (
+    CargoesTransportActivateRequest,
+    CargoesTransportActivateResponse,
+)
+from .v1__cargoes_transport_activate_status import (
+    CargoesTransportActivateStatusRequest,
+    CargoesTransportActivateStatusResponse,
+)
+from .v1__cargoes_transport_bind import (
+    CargoesTransportBindItem,
+    CargoesTransportBindRequest,
+    CargoesTransportBindResponse,
+)
+from .v1__cargoes_transport_bind_status import (
+    CargoesTransportBindStatusRequest,
+    CargoesTransportBindStatusResponse,
+)
+from .v1__cargoes_supplies_get import (
+    CargoesSuppliesGetCargo,
+    CargoesSuppliesGetRequest,
+    CargoesSuppliesGetResponse,
+    CargoesSuppliesGetSupply,
+    CargoesSuppliesGetTransportCargo,
+)
+from .v1__cargoes_label_transport_create import (
+    CargoesLabelTransportCreateRequest,
+    CargoesLabelTransportCreateResponse,
+)
+from .v1__cargoes_label_transport_status import (
+    CargoesLabelTransportStatusRequest,
+    CargoesLabelTransportStatusResponse,
+    CargoesLabelTransportStatusResult,
+)
+from .v1__cargoes_label_transport_by_order_create import (
+    CargoesLabelTransportByOrderCreateRequest,
+    CargoesLabelTransportByOrderCreateResponse,
+)
+from .v1__cargoes_label_transport_by_order_status import (
+    CargoesLabelTransportByOrderStatusRequest,
+    CargoesLabelTransportByOrderStatusResponse,
+    CargoesLabelTransportByOrderStatusResult,
 )
 from .v1__cargoes_rules_get import (
     CargoesRulesCargoCountPerType,

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_delete.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_delete.py
@@ -1,10 +1,16 @@
-"""Схемы метода cargoes_delete (удаление грузоместа, v1)."""
+"""Схемы метода cargoes_delete_v1 (удаление грузоместа, v1).
+
+Notes:
+    • Устаревшая версия. Ozon выпустил v2 `/v2/cargoes/delete`, поддерживающую
+      удаление транспортных грузомест; канонический метод — `cargoes_delete()`.
+      Данная v1-версия доступна как `cargoes_delete_v1()`.
+"""
 from typing import Optional
 
 from pydantic import BaseModel, Field
 
 
-class CargoesDeleteRequest(BaseModel):
+class CargoesDeleteV1Request(BaseModel):
     """Параметры запроса удаления грузомест.
 
     Attributes:
@@ -17,7 +23,7 @@ class CargoesDeleteRequest(BaseModel):
     supply_id: int = Field(..., description="Идентификатор поставки.")
 
 
-class CargoesDeleteCargoErrorReason(BaseModel):
+class CargoesDeleteV1CargoErrorReason(BaseModel):
     """Ошибки удаления конкретного грузоместа.
 
     Attributes:
@@ -30,14 +36,14 @@ class CargoesDeleteCargoErrorReason(BaseModel):
     )
 
 
-class CargoesDeleteErrors(BaseModel):
+class CargoesDeleteV1Errors(BaseModel):
     """Ошибки удаления грузомест.
 
     Attributes:
         cargo_error_reasons: Ошибки по отдельным грузоместам
         supply_error_reasons: Ошибки уровня поставки
     """
-    cargo_error_reasons: Optional[list[CargoesDeleteCargoErrorReason]] = Field(
+    cargo_error_reasons: Optional[list[CargoesDeleteV1CargoErrorReason]] = Field(
         None, description="Ошибки по отдельным грузоместам."
     )
     supply_error_reasons: Optional[list[str]] = Field(
@@ -45,14 +51,14 @@ class CargoesDeleteErrors(BaseModel):
     )
 
 
-class CargoesDeleteResponse(BaseModel):
+class CargoesDeleteV1Response(BaseModel):
     """Ответ на удаление грузомест.
 
     Attributes:
         errors: Ошибки операции
         operation_id: Идентификатор операции
     """
-    errors: Optional[CargoesDeleteErrors] = Field(
+    errors: Optional[CargoesDeleteV1Errors] = Field(
         None, description="Ошибки операции."
     )
     operation_id: Optional[str] = Field(

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_delete_status.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_delete_status.py
@@ -1,12 +1,17 @@
-"""Схемы метода cargoes_delete_status (статус удаления грузоместа, v1)."""
+"""Схемы метода cargoes_delete_status_v1 (статус удаления грузоместа, v1).
+
+Notes:
+    • Устаревшая версия. Канонический метод — `cargoes_delete_status()` (v2);
+      данная v1-версия доступна как `cargoes_delete_status_v1()`.
+"""
 from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from .v1__cargoes_delete import CargoesDeleteErrors
+from .v1__cargoes_delete import CargoesDeleteV1Errors
 
 
-class CargoesDeleteStatusRequest(BaseModel):
+class CargoesDeleteStatusV1Request(BaseModel):
     """Параметры запроса статуса удаления грузомест.
 
     Attributes:
@@ -17,14 +22,14 @@ class CargoesDeleteStatusRequest(BaseModel):
     )
 
 
-class CargoesDeleteStatusResponse(BaseModel):
+class CargoesDeleteStatusV1Response(BaseModel):
     """Ответ со статусом удаления грузомест.
 
     Attributes:
         errors: Ошибки операции
         status: Статус операции
     """
-    errors: Optional[CargoesDeleteErrors] = Field(
+    errors: Optional[CargoesDeleteV1Errors] = Field(
         None, description="Ошибки операции."
     )
     status: Optional[str] = Field(None, description="Статус операции.")

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_get.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_get.py
@@ -1,10 +1,16 @@
-"""Схемы метода cargoes_get (информация о грузоместах, v1)."""
+"""Схемы метода cargoes_get_v1 (информация о грузоместах, v1).
+
+Notes:
+    • Устаревшая версия. Ozon выпустил v2 `/v2/cargoes/get`, возвращающую данные
+      о транспортных грузоместах и лимитах; канонический метод — `cargoes_get()`.
+      Данная v1-версия доступна как `cargoes_get_v1()`.
+"""
 from typing import Optional
 
 from pydantic import BaseModel, Field
 
 
-class CargoesGetRequest(BaseModel):
+class CargoesGetV1Request(BaseModel):
     """Параметры запроса информации о грузоместах.
 
     Attributes:
@@ -15,7 +21,7 @@ class CargoesGetRequest(BaseModel):
     )
 
 
-class CargoesGetTrackingInfo(BaseModel):
+class CargoesGetV1TrackingInfo(BaseModel):
     """Информация об отслеживании грузоместа.
 
     Attributes:
@@ -28,7 +34,7 @@ class CargoesGetTrackingInfo(BaseModel):
     type: Optional[str] = Field(None, description="Тип события отслеживания.")
 
 
-class CargoesGetCargo(BaseModel):
+class CargoesGetV1Cargo(BaseModel):
     """Грузоместо поставки.
 
     Attributes:
@@ -49,13 +55,13 @@ class CargoesGetCargo(BaseModel):
     placement_zone_type: Optional[str] = Field(
         None, description="Тип зоны размещения."
     )
-    tracking_info: Optional[CargoesGetTrackingInfo] = Field(
+    tracking_info: Optional[CargoesGetV1TrackingInfo] = Field(
         None, description="Информация об отслеживании."
     )
     type: Optional[str] = Field(None, description="Тип грузоместа.")
 
 
-class CargoesGetSupply(BaseModel):
+class CargoesGetV1Supply(BaseModel):
     """Грузоместа поставки.
 
     Attributes:
@@ -66,18 +72,18 @@ class CargoesGetSupply(BaseModel):
     bundle_id: Optional[str] = Field(
         None, description="Идентификатор товарного состава."
     )
-    cargoes: Optional[list[CargoesGetCargo]] = Field(
+    cargoes: Optional[list[CargoesGetV1Cargo]] = Field(
         None, description="Грузоместа поставки."
     )
     supply_id: Optional[int] = Field(None, description="Идентификатор поставки.")
 
 
-class CargoesGetResponse(BaseModel):
+class CargoesGetV1Response(BaseModel):
     """Ответ с информацией о грузоместах.
 
     Attributes:
         supply: Поставки с грузоместами
     """
-    supply: Optional[list[CargoesGetSupply]] = Field(
+    supply: Optional[list[CargoesGetV1Supply]] = Field(
         None, description="Поставки с грузоместами."
     )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_by_order_create.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_by_order_create.py
@@ -1,0 +1,28 @@
+"""Схемы метода cargoes_label_transport_by_order_create (этикетки транспортных грузомест по поставке, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesLabelTransportByOrderCreateRequest(BaseModel):
+    """Параметры запроса генерации этикеток транспортных грузомест по поставке.
+
+    Attributes:
+        order_id: Идентификатор поставки
+    """
+    order_id: int = Field(..., description="Идентификатор поставки.")
+
+
+class CargoesLabelTransportByOrderCreateResponse(BaseModel):
+    """Ответ на генерацию этикеток транспортных грузомест по поставке.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        operation_id: Идентификатор операции
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    operation_id: Optional[str] = Field(
+        None, description="Идентификатор операции."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_by_order_status.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_by_order_status.py
@@ -1,0 +1,50 @@
+"""Схемы метода cargoes_label_transport_by_order_status (статус этикеток по поставке, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesLabelTransportByOrderStatusRequest(BaseModel):
+    """Параметры запроса статуса генерации этикеток транспортных грузомест по поставке.
+
+    Attributes:
+        operation_id: Идентификатор операции генерации этикеток
+    """
+    operation_id: str = Field(
+        ..., description="Идентификатор операции генерации этикеток."
+    )
+
+
+class CargoesLabelTransportByOrderStatusResult(BaseModel):
+    """Результат генерации этикеток транспортных грузомест по поставке.
+
+    Attributes:
+        file_url: Ссылка на файл с этикетками
+        skipped_supplies_ids: Идентификаторы пропущенных поставок
+    """
+    file_url: Optional[str] = Field(
+        None, description="Ссылка на файл с этикетками."
+    )
+    skipped_supplies_ids: Optional[list[str]] = Field(
+        None, description="Идентификаторы пропущенных поставок."
+    )
+
+
+class CargoesLabelTransportByOrderStatusResponse(BaseModel):
+    """Ответ со статусом генерации этикеток транспортных грузомест по поставке.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        result: Результат генерации
+        status: Статус операции (`SUCCESS`, `IN_PROGRESS`, `FAILED`)
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    result: Optional[CargoesLabelTransportByOrderStatusResult] = Field(
+        None, description="Результат генерации."
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Статус операции. Возможные значения: `SUCCESS`, `IN_PROGRESS`, `FAILED`."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_create.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_create.py
@@ -1,0 +1,32 @@
+"""Схемы метода cargoes_label_transport_create (этикетки транспортных грузомест по грузоместу, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesLabelTransportCreateRequest(BaseModel):
+    """Параметры запроса генерации этикеток транспортных грузомест.
+
+    Attributes:
+        supply_id: Идентификатор поставки
+        transport_cargo_ids: Идентификаторы транспортных грузомест
+    """
+    supply_id: int = Field(..., description="Идентификатор поставки.")
+    transport_cargo_ids: Optional[list[str]] = Field(
+        None, description="Идентификаторы транспортных грузомест."
+    )
+
+
+class CargoesLabelTransportCreateResponse(BaseModel):
+    """Ответ на генерацию этикеток транспортных грузомест.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        operation_id: Идентификатор операции
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    operation_id: Optional[str] = Field(
+        None, description="Идентификатор операции."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_status.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_label_transport_status.py
@@ -1,0 +1,46 @@
+"""Схемы метода cargoes_label_transport_status (статус этикеток транспортных грузомест, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesLabelTransportStatusRequest(BaseModel):
+    """Параметры запроса статуса генерации этикеток транспортных грузомест.
+
+    Attributes:
+        operation_id: Идентификатор операции генерации этикеток
+    """
+    operation_id: str = Field(
+        ..., description="Идентификатор операции генерации этикеток."
+    )
+
+
+class CargoesLabelTransportStatusResult(BaseModel):
+    """Результат генерации этикеток транспортных грузомест.
+
+    Attributes:
+        file_url: Ссылка на файл с этикетками
+    """
+    file_url: Optional[str] = Field(
+        None, description="Ссылка на файл с этикетками."
+    )
+
+
+class CargoesLabelTransportStatusResponse(BaseModel):
+    """Ответ со статусом генерации этикеток транспортных грузомест.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        result: Результат генерации
+        status: Статус операции (`SUCCESS`, `IN_PROGRESS`, `FAILED`)
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    result: Optional[CargoesLabelTransportStatusResult] = Field(
+        None, description="Результат генерации."
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Статус операции. Возможные значения: `SUCCESS`, `IN_PROGRESS`, `FAILED`."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_supplies_get.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_supplies_get.py
@@ -1,0 +1,87 @@
+"""Схемы метода cargoes_supplies_get (грузоместа в поставках, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesSuppliesGetRequest(BaseModel):
+    """Параметры запроса информации о грузоместах в поставках.
+
+    Attributes:
+        supply_ids: Идентификаторы поставок
+    """
+    supply_ids: list[str] = Field(..., description="Идентификаторы поставок.")
+
+
+class CargoesSuppliesGetCargo(BaseModel):
+    """Грузоместо поставки.
+
+    Attributes:
+        barcode: Штрихкод грузоместа
+        bundle_id: Идентификатор товарного состава
+        cargo_id: Идентификатор грузоместа
+    """
+    barcode: Optional[str] = Field(None, description="Штрихкод грузоместа.")
+    bundle_id: Optional[str] = Field(
+        None, description="Идентификатор товарного состава."
+    )
+    cargo_id: Optional[int] = Field(None, description="Идентификатор грузоместа.")
+
+
+class CargoesSuppliesGetTransportCargo(BaseModel):
+    """Транспортное грузоместо поставки.
+
+    Attributes:
+        bundle_id: Идентификатор товарного состава
+        cargoes: Вложенные грузоместа
+        transport_cargo_id: Идентификатор транспортного грузоместа
+        type: Тип транспортного грузоместа (`PALLET`)
+    """
+    bundle_id: Optional[str] = Field(
+        None, description="Идентификатор товарного состава."
+    )
+    cargoes: Optional[list[CargoesSuppliesGetCargo]] = Field(
+        None, description="Вложенные грузоместа."
+    )
+    transport_cargo_id: Optional[int] = Field(
+        None, description="Идентификатор транспортного грузоместа."
+    )
+    type: Optional[str] = Field(
+        None, description="Тип транспортного грузоместа. Возможное значение: `PALLET`."
+    )
+
+
+class CargoesSuppliesGetSupply(BaseModel):
+    """Грузоместа поставки.
+
+    Attributes:
+        bundle_id: Идентификатор товарного состава
+        cargoes_without_transport_cargoes: Грузоместа без транспортных грузомест
+        supply_id: Идентификатор поставки
+        transport_cargoes: Транспортные грузоместа поставки
+    """
+    bundle_id: Optional[str] = Field(
+        None, description="Идентификатор товарного состава."
+    )
+    cargoes_without_transport_cargoes: Optional[
+        list[CargoesSuppliesGetCargo]
+    ] = Field(None, description="Грузоместа без транспортных грузомест.")
+    supply_id: Optional[int] = Field(None, description="Идентификатор поставки.")
+    transport_cargoes: Optional[
+        list[CargoesSuppliesGetTransportCargo]
+    ] = Field(None, description="Транспортные грузоместа поставки.")
+
+
+class CargoesSuppliesGetResponse(BaseModel):
+    """Ответ с информацией о грузоместах в поставках.
+
+    Attributes:
+        not_found_supply_ids: Идентификаторы ненайденных поставок
+        supplies_cargoes: Грузоместа по поставкам
+    """
+    not_found_supply_ids: Optional[list[str]] = Field(
+        None, description="Идентификаторы ненайденных поставок."
+    )
+    supplies_cargoes: Optional[list[CargoesSuppliesGetSupply]] = Field(
+        None, description="Грузоместа по поставкам."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_activate.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_activate.py
@@ -1,0 +1,28 @@
+"""Схемы метода cargoes_transport_activate (включение транспортных грузомест, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesTransportActivateRequest(BaseModel):
+    """Параметры запроса включения или отключения транспортных грузомест.
+
+    Attributes:
+        is_transport: Признак включения транспортных грузомест в поставке
+        supply_id: Идентификатор поставки
+    """
+    is_transport: bool = Field(
+        ..., description="Признак включения транспортных грузомест в поставке."
+    )
+    supply_id: int = Field(..., description="Идентификатор поставки.")
+
+
+class CargoesTransportActivateResponse(BaseModel):
+    """Ответ на включение или отключение транспортных грузомест.
+
+    Attributes:
+        operation_id: Идентификатор операции
+    """
+    operation_id: Optional[str] = Field(
+        None, description="Идентификатор операции."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_activate_status.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_activate_status.py
@@ -1,0 +1,31 @@
+"""Схемы метода cargoes_transport_activate_status (статус включения транспортных грузомест, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesTransportActivateStatusRequest(BaseModel):
+    """Параметры запроса статуса включения транспортных грузомест.
+
+    Attributes:
+        operation_id: Идентификатор операции включения транспортных грузомест
+    """
+    operation_id: str = Field(
+        ..., description="Идентификатор операции включения транспортных грузомест."
+    )
+
+
+class CargoesTransportActivateStatusResponse(BaseModel):
+    """Ответ со статусом включения или отключения транспортных грузомест.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        status: Статус операции (`SUCCESS`, `IN_PROGRESS`, `FAILED`)
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Статус операции. Возможные значения: `SUCCESS`, `IN_PROGRESS`, `FAILED`."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_bind.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_bind.py
@@ -1,0 +1,49 @@
+"""Схемы метода cargoes_transport_bind (связывание грузомест и транспортных грузомест, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesTransportBindItem(BaseModel):
+    """Связывание грузомест с транспортным грузоместом.
+
+    Attributes:
+        cargo_ids: Идентификаторы грузомест
+        transport_cargo_id: Идентификатор транспортного грузоместа
+    """
+    cargo_ids: list[str] = Field(..., description="Идентификаторы грузомест.")
+    transport_cargo_id: int = Field(
+        ..., description="Идентификатор транспортного грузоместа."
+    )
+
+
+class CargoesTransportBindRequest(BaseModel):
+    """Параметры запроса связывания или отвязывания грузомест и транспортных грузомест.
+
+    Attributes:
+        cargoes_unbind_transport_cargoes: Идентификаторы грузомест для отвязывания
+        supply_id: Идентификатор поставки
+        transport_cargo_bind: Связывания грузомест с транспортными грузоместами
+    """
+    cargoes_unbind_transport_cargoes: Optional[list[str]] = Field(
+        None, description="Идентификаторы грузомест для отвязывания."
+    )
+    supply_id: int = Field(..., description="Идентификатор поставки.")
+    transport_cargo_bind: Optional[list[CargoesTransportBindItem]] = Field(
+        None, description="Связывания грузомест с транспортными грузоместами."
+    )
+
+
+class CargoesTransportBindResponse(BaseModel):
+    """Ответ на связывание или отвязывание грузомест и транспортных грузомест.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        operation_id: Идентификатор операции
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    operation_id: Optional[str] = Field(
+        None, description="Идентификатор операции."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_bind_status.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_bind_status.py
@@ -1,0 +1,31 @@
+"""Схемы метода cargoes_transport_bind_status (статус связывания грузомест, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesTransportBindStatusRequest(BaseModel):
+    """Параметры запроса статуса связывания грузомест и транспортных грузомест.
+
+    Attributes:
+        operation_id: Идентификатор операции связывания грузомест
+    """
+    operation_id: str = Field(
+        ..., description="Идентификатор операции связывания грузомест."
+    )
+
+
+class CargoesTransportBindStatusResponse(BaseModel):
+    """Ответ со статусом связывания или отвязывания грузомест.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        status: Статус операции (`SUCCESS`, `IN_PROGRESS`, `FAILED`)
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Статус операции. Возможные значения: `SUCCESS`, `IN_PROGRESS`, `FAILED`."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_create.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_create.py
@@ -1,0 +1,45 @@
+"""Схемы метода cargoes_transport_create (создание транспортного грузоместа, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesTransportCreateItem(BaseModel):
+    """Транспортное грузоместо для создания.
+
+    Attributes:
+        count: Количество транспортных грузомест
+        type: Тип транспортного грузоместа (`PALLET`)
+    """
+    count: int = Field(..., description="Количество транспортных грузомест.")
+    type: str = Field(
+        ..., description="Тип транспортного грузоместа. Возможное значение: `PALLET`."
+    )
+
+
+class CargoesTransportCreateRequest(BaseModel):
+    """Параметры запроса создания транспортных грузомест.
+
+    Attributes:
+        supply_id: Идентификатор поставки
+        transport_cargoes: Транспортные грузоместа для создания
+    """
+    supply_id: int = Field(..., description="Идентификатор поставки.")
+    transport_cargoes: list[CargoesTransportCreateItem] = Field(
+        ..., description="Транспортные грузоместа для создания."
+    )
+
+
+class CargoesTransportCreateResponse(BaseModel):
+    """Ответ на создание транспортных грузомест.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        operation_id: Идентификатор операции
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    operation_id: Optional[str] = Field(
+        None, description="Идентификатор операции."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_create_status.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v1__cargoes_transport_create_status.py
@@ -1,0 +1,61 @@
+"""Схемы метода cargoes_transport_create_status (статус создания транспортного грузоместа, v1)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesTransportCreateStatusRequest(BaseModel):
+    """Параметры запроса статуса создания транспортных грузомест.
+
+    Attributes:
+        operation_id: Идентификатор операции создания транспортных грузомест
+    """
+    operation_id: str = Field(
+        ..., description="Идентификатор операции создания транспортных грузомест."
+    )
+
+
+class CargoesTransportCreateStatusTransportCargo(BaseModel):
+    """Созданное транспортное грузоместо.
+
+    Attributes:
+        id: Идентификатор транспортного грузоместа
+        type: Тип транспортного грузоместа (`PALLET`)
+    """
+    id: Optional[int] = Field(
+        None, description="Идентификатор транспортного грузоместа."
+    )
+    type: Optional[str] = Field(
+        None, description="Тип транспортного грузоместа. Возможное значение: `PALLET`."
+    )
+
+
+class CargoesTransportCreateStatusResult(BaseModel):
+    """Результат создания транспортных грузомест.
+
+    Attributes:
+        transport_cargoes: Созданные транспортные грузоместа
+    """
+    transport_cargoes: Optional[
+        list[CargoesTransportCreateStatusTransportCargo]
+    ] = Field(None, description="Созданные транспортные грузоместа.")
+
+
+class CargoesTransportCreateStatusResponse(BaseModel):
+    """Ответ со статусом создания транспортных грузомест.
+
+    Attributes:
+        error_reasons: Причины ошибок
+        result: Результат создания
+        status: Статус операции (`SUCCESS`, `IN_PROGRESS`, `FAILED`)
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибок."
+    )
+    result: Optional[CargoesTransportCreateStatusResult] = Field(
+        None, description="Результат создания."
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Статус операции. Возможные значения: `SUCCESS`, `IN_PROGRESS`, `FAILED`."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v2__cargoes_delete.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v2__cargoes_delete.py
@@ -1,0 +1,94 @@
+"""Схемы метода cargoes_delete (удаление грузомест и транспортных грузомест, v2)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesDeleteRequest(BaseModel):
+    """Параметры запроса удаления грузомест и транспортных грузомест.
+
+    Attributes:
+        cargo_ids: Идентификаторы грузомест
+        supply_id: Идентификатор поставки
+        transport_cargo_deletion_type: Способ удаления транспортных грузомест
+            (`UNBIND_CONTAINED_CARGOES` — отвязать вложенные грузоместа,
+            `DELETE_CONTAINED_CARGOES` — удалить вложенные грузоместа)
+        transport_cargo_ids: Идентификаторы транспортных грузомест
+    """
+    cargo_ids: Optional[list[str]] = Field(
+        None, description="Идентификаторы грузомест."
+    )
+    supply_id: int = Field(..., description="Идентификатор поставки.")
+    transport_cargo_deletion_type: str = Field(
+        ...,
+        description=(
+            "Способ удаления транспортных грузомест. Возможные значения: "
+            "`UNBIND_CONTAINED_CARGOES` — отвязать вложенные грузоместа, "
+            "`DELETE_CONTAINED_CARGOES` — удалить вложенные грузоместа."
+        )
+    )
+    transport_cargo_ids: Optional[list[str]] = Field(
+        None, description="Идентификаторы транспортных грузомест."
+    )
+
+
+class CargoesDeleteCargoErrorReason(BaseModel):
+    """Ошибки удаления конкретного грузоместа.
+
+    Attributes:
+        cargo_id: Идентификатор грузоместа
+        error_reasons: Причины ошибки
+    """
+    cargo_id: Optional[int] = Field(None, description="Идентификатор грузоместа.")
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибки."
+    )
+
+
+class CargoesDeleteTransportCargoErrorReason(BaseModel):
+    """Ошибки удаления конкретного транспортного грузоместа.
+
+    Attributes:
+        error_reasons: Причины ошибки
+        transport_cargo_id: Идентификатор транспортного грузоместа
+    """
+    error_reasons: Optional[list[str]] = Field(
+        None, description="Причины ошибки."
+    )
+    transport_cargo_id: Optional[int] = Field(
+        None, description="Идентификатор транспортного грузоместа."
+    )
+
+
+class CargoesDeleteErrors(BaseModel):
+    """Ошибки удаления грузомест и транспортных грузомест.
+
+    Attributes:
+        cargo_error_reasons: Ошибки по отдельным грузоместам
+        supply_error_reasons: Ошибки уровня поставки
+        transport_cargo_error_reasons: Ошибки по транспортным грузоместам
+    """
+    cargo_error_reasons: Optional[list[CargoesDeleteCargoErrorReason]] = Field(
+        None, description="Ошибки по отдельным грузоместам."
+    )
+    supply_error_reasons: Optional[list[str]] = Field(
+        None, description="Ошибки уровня поставки."
+    )
+    transport_cargo_error_reasons: Optional[
+        list[CargoesDeleteTransportCargoErrorReason]
+    ] = Field(None, description="Ошибки по транспортным грузоместам.")
+
+
+class CargoesDeleteResponse(BaseModel):
+    """Ответ на удаление грузомест и транспортных грузомест.
+
+    Attributes:
+        errors: Ошибки операции
+        operation_id: Идентификатор операции
+    """
+    errors: Optional[CargoesDeleteErrors] = Field(
+        None, description="Ошибки операции."
+    )
+    operation_id: Optional[str] = Field(
+        None, description="Идентификатор операции."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v2__cargoes_delete_status.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v2__cargoes_delete_status.py
@@ -1,0 +1,33 @@
+"""Схемы метода cargoes_delete_status (статус удаления грузомест, v2)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from .v2__cargoes_delete import CargoesDeleteErrors
+
+
+class CargoesDeleteStatusRequest(BaseModel):
+    """Параметры запроса статуса удаления грузомест и транспортных грузомест.
+
+    Attributes:
+        operation_id: Идентификатор операции удаления грузомест
+    """
+    operation_id: str = Field(
+        ..., description="Идентификатор операции удаления грузомест."
+    )
+
+
+class CargoesDeleteStatusResponse(BaseModel):
+    """Ответ со статусом удаления грузомест и транспортных грузомест.
+
+    Attributes:
+        errors: Ошибки операции
+        status: Статус операции (`SUCCESS`, `IN_PROGRESS`, `FAILED`)
+    """
+    errors: Optional[CargoesDeleteErrors] = Field(
+        None, description="Ошибки операции."
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Статус операции. Возможные значения: `SUCCESS`, `IN_PROGRESS`, `FAILED`."
+    )

--- a/src/ozonapi/seller/schemas/fbo_supply_request/v2__cargoes_get.py
+++ b/src/ozonapi/seller/schemas/fbo_supply_request/v2__cargoes_get.py
@@ -1,0 +1,230 @@
+"""Схемы метода cargoes_get (информация о грузоместах, v2)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CargoesGetSupplyRequest(BaseModel):
+    """Поставка с грузоместами для запроса.
+
+    Attributes:
+        cargo_ids: Идентификаторы грузомест
+        supply_id: Идентификатор поставки
+    """
+    cargo_ids: list[str] = Field(..., description="Идентификаторы грузомест.")
+    supply_id: int = Field(..., description="Идентификатор поставки.")
+
+
+class CargoesGetRequest(BaseModel):
+    """Параметры запроса информации о грузоместах.
+
+    Attributes:
+        supplies: Поставки с грузоместами
+    """
+    supplies: list[CargoesGetSupplyRequest] = Field(
+        ..., description="Поставки с грузоместами."
+    )
+
+
+class CargoesGetTimezone(BaseModel):
+    """Часовой пояс времени прибытия.
+
+    Attributes:
+        iana_name: Наименование часового пояса в формате IANA
+        offset: Смещение от UTC в секундах
+    """
+    iana_name: Optional[str] = Field(
+        None, description="Наименование часового пояса в формате IANA."
+    )
+    offset: Optional[int] = Field(
+        None, description="Смещение от UTC в секундах."
+    )
+
+
+class CargoesGetArrivalAt(BaseModel):
+    """Время прибытия грузоместа.
+
+    Attributes:
+        date: Дата и время прибытия
+        timezone_info: Часовой пояс
+    """
+    date: Optional[str] = Field(None, description="Дата и время прибытия.")
+    timezone_info: Optional[CargoesGetTimezone] = Field(
+        None, description="Часовой пояс."
+    )
+
+
+class CargoesGetTrackingInfo(BaseModel):
+    """Информация об отслеживании грузоместа.
+
+    Attributes:
+        arrival_at: Время прибытия
+        status: Статус грузоместа
+        type: Тип события (`EXPECTED_ARRIVAL`, `ACTUAL_ARRIVAL`)
+    """
+    arrival_at: Optional[CargoesGetArrivalAt] = Field(
+        None, description="Время прибытия."
+    )
+    status: Optional[str] = Field(None, description="Статус грузоместа.")
+    type: Optional[str] = Field(
+        None,
+        description="Тип события. Возможные значения: `EXPECTED_ARRIVAL`, `ACTUAL_ARRIVAL`."
+    )
+
+
+class CargoesGetCargo(BaseModel):
+    """Грузоместо поставки.
+
+    Attributes:
+        bundle_id: Идентификатор товарного состава
+        cargo_id: Идентификатор грузоместа
+        content_type: Тип содержимого (`MONO`, `MIX`, `NONE`)
+        placement_zone_type: Тип зоны размещения (`TYPE_SINGLE`, `MULTI`)
+        tracking_info: Информация об отслеживании
+        transport_cargo_id: Идентификатор транспортного грузоместа
+        type: Тип грузоместа (`BOX`, `PALLET`)
+    """
+    bundle_id: Optional[str] = Field(
+        None, description="Идентификатор товарного состава."
+    )
+    cargo_id: Optional[int] = Field(None, description="Идентификатор грузоместа.")
+    content_type: Optional[str] = Field(
+        None,
+        description="Тип содержимого. Возможные значения: `MONO`, `MIX`, `NONE`."
+    )
+    placement_zone_type: Optional[str] = Field(
+        None,
+        description="Тип зоны размещения. Возможные значения: `TYPE_SINGLE`, `MULTI`."
+    )
+    tracking_info: Optional[CargoesGetTrackingInfo] = Field(
+        None, description="Информация об отслеживании."
+    )
+    transport_cargo_id: Optional[int] = Field(
+        None, description="Идентификатор транспортного грузоместа."
+    )
+    type: Optional[str] = Field(
+        None, description="Тип грузоместа. Возможные значения: `BOX`, `PALLET`."
+    )
+
+
+class CargoesGetLimits(BaseModel):
+    """Лимиты поставки по грузоместам.
+
+    Attributes:
+        max_box_count: Максимальное число коробок
+        max_box_sku_count: Максимальное число SKU в коробке
+        max_pallet_count: Максимальное число паллет
+        max_transport_pallet_count: Максимальное число транспортных паллет
+    """
+    max_box_count: Optional[int] = Field(
+        None, description="Максимальное число коробок."
+    )
+    max_box_sku_count: Optional[int] = Field(
+        None, description="Максимальное число SKU в коробке."
+    )
+    max_pallet_count: Optional[int] = Field(
+        None, description="Максимальное число паллет."
+    )
+    max_transport_pallet_count: Optional[int] = Field(
+        None, description="Максимальное число транспортных паллет."
+    )
+
+
+class CargoesGetTransportArrivalAt(BaseModel):
+    """Время прибытия транспортного грузоместа.
+
+    Attributes:
+        date: Дата и время прибытия
+        timezone: Часовой пояс
+    """
+    date: Optional[str] = Field(None, description="Дата и время прибытия.")
+    timezone: Optional[CargoesGetTimezone] = Field(
+        None, description="Часовой пояс."
+    )
+
+
+class CargoesGetTransportTrackingInfo(BaseModel):
+    """Информация об отслеживании транспортного грузоместа.
+
+    Attributes:
+        arrival_at: Время прибытия
+        status: Статус транспортного грузоместа
+        type: Тип события (`EXPECTED_ARRIVAL`, `ACTUAL_ARRIVAL`)
+    """
+    arrival_at: Optional[CargoesGetTransportArrivalAt] = Field(
+        None, description="Время прибытия."
+    )
+    status: Optional[str] = Field(
+        None, description="Статус транспортного грузоместа."
+    )
+    type: Optional[str] = Field(
+        None,
+        description="Тип события. Возможные значения: `EXPECTED_ARRIVAL`, `ACTUAL_ARRIVAL`."
+    )
+
+
+class CargoesGetTransportCargo(BaseModel):
+    """Транспортное грузоместо поставки.
+
+    Attributes:
+        box_count: Число коробок в транспортном грузоместе
+        summary_bundle_id: Идентификатор сводного товарного состава
+        tracking_info: Информация об отслеживании
+        transport_cargo_id: Идентификатор транспортного грузоместа
+        type: Тип транспортного грузоместа (`PALLET`)
+    """
+    box_count: Optional[int] = Field(
+        None, description="Число коробок в транспортном грузоместе."
+    )
+    summary_bundle_id: Optional[str] = Field(
+        None, description="Идентификатор сводного товарного состава."
+    )
+    tracking_info: Optional[CargoesGetTransportTrackingInfo] = Field(
+        None, description="Информация об отслеживании."
+    )
+    transport_cargo_id: Optional[int] = Field(
+        None, description="Идентификатор транспортного грузоместа."
+    )
+    type: Optional[str] = Field(
+        None, description="Тип транспортного грузоместа. Возможное значение: `PALLET`."
+    )
+
+
+class CargoesGetSupply(BaseModel):
+    """Грузоместа поставки.
+
+    Attributes:
+        bundle_id: Идентификатор товарного состава
+        cargoes: Грузоместа поставки
+        cargoes_bundle_id: Идентификатор товарного состава грузомест
+        limits: Лимиты поставки
+        supply_id: Идентификатор поставки
+        transport_cargoes: Транспортные грузоместа поставки
+    """
+    bundle_id: Optional[str] = Field(
+        None, description="Идентификатор товарного состава."
+    )
+    cargoes: Optional[list[CargoesGetCargo]] = Field(
+        None, description="Грузоместа поставки."
+    )
+    cargoes_bundle_id: Optional[str] = Field(
+        None, description="Идентификатор товарного состава грузомест."
+    )
+    limits: Optional[CargoesGetLimits] = Field(
+        None, description="Лимиты поставки."
+    )
+    supply_id: Optional[int] = Field(None, description="Идентификатор поставки.")
+    transport_cargoes: Optional[list[CargoesGetTransportCargo]] = Field(
+        None, description="Транспортные грузоместа поставки."
+    )
+
+
+class CargoesGetResponse(BaseModel):
+    """Ответ с информацией о грузоместах.
+
+    Attributes:
+        supplies: Поставки с грузоместами
+    """
+    supplies: Optional[list[CargoesGetSupply]] = Field(
+        None, description="Поставки с грузоместами."
+    )

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_delete.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_delete.py
@@ -7,7 +7,7 @@ from src.ozonapi.seller.schemas.fbo_supply_request import (
 
 
 class TestCargoesDelete:
-    """Тесты для метода cargoes_delete."""
+    """Тесты для метода cargoes_delete (v2)."""
 
     @pytest.mark.asyncio
     async def test_cargoes_delete(self, api, mock_api_request):
@@ -18,16 +18,21 @@ class TestCargoesDelete:
             "errors": {
                 "cargo_error_reasons": [],
                 "supply_error_reasons": [],
+                "transport_cargo_error_reasons": [],
             },
         }
 
-        request = CargoesDeleteRequest(supply_id=123, cargo_ids=["1", "2"])
+        request = CargoesDeleteRequest(
+            supply_id=123,
+            cargo_ids=["1", "2"],
+            transport_cargo_deletion_type="UNBIND_CONTAINED_CARGOES",
+        )
 
         response = await api.cargoes_delete(request)
 
         mock_api_request.assert_called_once_with(
             method="post",
-            api_version="v1",
+            api_version="v2",
             endpoint="cargoes/delete",
             payload=request.model_dump(by_alias=True)
         )

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_delete_status.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_delete_status.py
@@ -7,7 +7,7 @@ from src.ozonapi.seller.schemas.fbo_supply_request import (
 
 
 class TestCargoesDeleteStatus:
-    """Тесты для метода cargoes_delete_status."""
+    """Тесты для метода cargoes_delete_status (v2)."""
 
     @pytest.mark.asyncio
     async def test_cargoes_delete_status(self, api, mock_api_request):
@@ -17,6 +17,7 @@ class TestCargoesDeleteStatus:
             "errors": {
                 "cargo_error_reasons": [],
                 "supply_error_reasons": [],
+                "transport_cargo_error_reasons": [],
             },
             "status": "SUCCESS",
         }
@@ -27,7 +28,7 @@ class TestCargoesDeleteStatus:
 
         mock_api_request.assert_called_once_with(
             method="post",
-            api_version="v1",
+            api_version="v2",
             endpoint="cargoes/delete/status",
             payload=request.model_dump(by_alias=True)
         )

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_delete_status_v1.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_delete_status_v1.py
@@ -1,0 +1,36 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesDeleteStatusV1Request,
+    CargoesDeleteStatusV1Response,
+)
+
+
+class TestCargoesDeleteStatusV1:
+    """Тесты для метода cargoes_delete_status_v1."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_delete_status_v1(self, api, mock_api_request):
+        """Тестирует метод cargoes_delete_status_v1."""
+
+        mock_api_request.return_value = {
+            "errors": {
+                "cargo_error_reasons": [],
+                "supply_error_reasons": [],
+            },
+            "status": "SUCCESS",
+        }
+
+        request = CargoesDeleteStatusV1Request(operation_id="op-del-1")
+
+        response = await api.cargoes_delete_status_v1(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/delete/status",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesDeleteStatusV1Response)
+        assert response.status == "SUCCESS"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_delete_v1.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_delete_v1.py
@@ -1,0 +1,36 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesDeleteV1Request,
+    CargoesDeleteV1Response,
+)
+
+
+class TestCargoesDeleteV1:
+    """Тесты для метода cargoes_delete_v1."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_delete_v1(self, api, mock_api_request):
+        """Тестирует метод cargoes_delete_v1."""
+
+        mock_api_request.return_value = {
+            "operation_id": "op-del-1",
+            "errors": {
+                "cargo_error_reasons": [],
+                "supply_error_reasons": [],
+            },
+        }
+
+        request = CargoesDeleteV1Request(supply_id=123, cargo_ids=["1", "2"])
+
+        response = await api.cargoes_delete_v1(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/delete",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesDeleteV1Response)
+        assert response.operation_id == "op-del-1"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_get.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_get.py
@@ -3,49 +3,73 @@ import pytest
 from src.ozonapi.seller.schemas.fbo_supply_request import (
     CargoesGetRequest,
     CargoesGetResponse,
+    CargoesGetSupplyRequest,
 )
 
 
 class TestCargoesGet:
-    """Тесты для метода cargoes_get."""
+    """Тесты для метода cargoes_get (v2)."""
 
     @pytest.mark.asyncio
     async def test_cargoes_get(self, api, mock_api_request):
         """Тестирует метод cargoes_get."""
 
         mock_api_request.return_value = {
-            "supply": [
+            "supplies": [
                 {
                     "bundle_id": "b1",
                     "supply_id": 123,
+                    "cargoes_bundle_id": "cb1",
+                    "limits": {
+                        "max_box_count": 10,
+                        "max_pallet_count": 2,
+                    },
                     "cargoes": [
                         {
                             "cargo_id": 1,
-                            "content_type": "SKU",
-                            "placement_zone_type": "COLD",
+                            "content_type": "MONO",
+                            "placement_zone_type": "TYPE_SINGLE",
                             "type": "BOX",
+                            "transport_cargo_id": 10,
                             "tracking_info": {
-                                "date": "2026-06-01T00:00:00Z",
-                                "status": "ACCEPTED",
-                                "type": "ARRIVAL",
+                                "status": "ON_WAREHOUSE",
+                                "type": "ACTUAL_ARRIVAL",
+                                "arrival_at": {
+                                    "date": "2026-06-01T00:00:00Z",
+                                    "timezone_info": {
+                                        "iana_name": "Europe/Moscow",
+                                        "offset": 10800,
+                                    },
+                                },
                             },
+                        }
+                    ],
+                    "transport_cargoes": [
+                        {
+                            "transport_cargo_id": 10,
+                            "type": "PALLET",
+                            "box_count": 5,
+                            "summary_bundle_id": "sb1",
                         }
                     ],
                 }
             ]
         }
 
-        request = CargoesGetRequest(supply_ids=["123"])
+        request = CargoesGetRequest(
+            supplies=[CargoesGetSupplyRequest(supply_id=123, cargo_ids=["1"])]
+        )
 
         response = await api.cargoes_get(request)
 
         mock_api_request.assert_called_once_with(
             method="post",
-            api_version="v1",
+            api_version="v2",
             endpoint="cargoes/get",
             payload=request.model_dump(by_alias=True)
         )
 
         assert isinstance(response, CargoesGetResponse)
-        assert response.supply[0].supply_id == 123
-        assert response.supply[0].cargoes[0].cargo_id == 1
+        assert response.supplies[0].supply_id == 123
+        assert response.supplies[0].cargoes[0].cargo_id == 1
+        assert response.supplies[0].transport_cargoes[0].transport_cargo_id == 10

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_get_v1.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_get_v1.py
@@ -1,0 +1,51 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesGetV1Request,
+    CargoesGetV1Response,
+)
+
+
+class TestCargoesGetV1:
+    """Тесты для метода cargoes_get_v1."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_get_v1(self, api, mock_api_request):
+        """Тестирует метод cargoes_get_v1."""
+
+        mock_api_request.return_value = {
+            "supply": [
+                {
+                    "bundle_id": "b1",
+                    "supply_id": 123,
+                    "cargoes": [
+                        {
+                            "cargo_id": 1,
+                            "content_type": "SKU",
+                            "placement_zone_type": "COLD",
+                            "type": "BOX",
+                            "tracking_info": {
+                                "date": "2026-06-01T00:00:00Z",
+                                "status": "ACCEPTED",
+                                "type": "ARRIVAL",
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+
+        request = CargoesGetV1Request(supply_ids=["123"])
+
+        response = await api.cargoes_get_v1(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/get",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesGetV1Response)
+        assert response.supply[0].supply_id == 123
+        assert response.supply[0].cargoes[0].cargo_id == 1

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_by_order_create.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_by_order_create.py
@@ -1,0 +1,35 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesLabelTransportByOrderCreateRequest,
+    CargoesLabelTransportByOrderCreateResponse,
+)
+
+
+class TestCargoesLabelTransportByOrderCreate:
+    """Тесты для метода cargoes_label_transport_by_order_create."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_label_transport_by_order_create(
+        self, api, mock_api_request
+    ):
+        """Тестирует метод cargoes_label_transport_by_order_create."""
+
+        mock_api_request.return_value = {
+            "operation_id": "op-lto-1",
+            "error_reasons": [],
+        }
+
+        request = CargoesLabelTransportByOrderCreateRequest(order_id=123)
+
+        response = await api.cargoes_label_transport_by_order_create(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport-by-order/create",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesLabelTransportByOrderCreateResponse)
+        assert response.operation_id == "op-lto-1"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_by_order_status.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_by_order_status.py
@@ -1,0 +1,39 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesLabelTransportByOrderStatusRequest,
+    CargoesLabelTransportByOrderStatusResponse,
+)
+
+
+class TestCargoesLabelTransportByOrderStatus:
+    """Тесты для метода cargoes_label_transport_by_order_status."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_label_transport_by_order_status(
+        self, api, mock_api_request
+    ):
+        """Тестирует метод cargoes_label_transport_by_order_status."""
+
+        mock_api_request.return_value = {
+            "status": "SUCCESS",
+            "error_reasons": [],
+            "result": {
+                "file_url": "https://example.com/label.pdf",
+                "skipped_supplies_ids": [],
+            },
+        }
+
+        request = CargoesLabelTransportByOrderStatusRequest(operation_id="op-lto-1")
+
+        response = await api.cargoes_label_transport_by_order_status(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport-by-order/status",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesLabelTransportByOrderStatusResponse)
+        assert response.result.file_url == "https://example.com/label.pdf"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_create.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_create.py
@@ -1,0 +1,35 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesLabelTransportCreateRequest,
+    CargoesLabelTransportCreateResponse,
+)
+
+
+class TestCargoesLabelTransportCreate:
+    """Тесты для метода cargoes_label_transport_create."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_label_transport_create(self, api, mock_api_request):
+        """Тестирует метод cargoes_label_transport_create."""
+
+        mock_api_request.return_value = {
+            "operation_id": "op-lt-1",
+            "error_reasons": [],
+        }
+
+        request = CargoesLabelTransportCreateRequest(
+            supply_id=123, transport_cargo_ids=["10"]
+        )
+
+        response = await api.cargoes_label_transport_create(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport/create",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesLabelTransportCreateResponse)
+        assert response.operation_id == "op-lt-1"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_status.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_label_transport_status.py
@@ -1,0 +1,34 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesLabelTransportStatusRequest,
+    CargoesLabelTransportStatusResponse,
+)
+
+
+class TestCargoesLabelTransportStatus:
+    """Тесты для метода cargoes_label_transport_status."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_label_transport_status(self, api, mock_api_request):
+        """Тестирует метод cargoes_label_transport_status."""
+
+        mock_api_request.return_value = {
+            "status": "SUCCESS",
+            "error_reasons": [],
+            "result": {"file_url": "https://example.com/label.pdf"},
+        }
+
+        request = CargoesLabelTransportStatusRequest(operation_id="op-lt-1")
+
+        response = await api.cargoes_label_transport_status(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/label/transport/status",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesLabelTransportStatusResponse)
+        assert response.result.file_url == "https://example.com/label.pdf"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_supplies_get.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_supplies_get.py
@@ -1,0 +1,50 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesSuppliesGetRequest,
+    CargoesSuppliesGetResponse,
+)
+
+
+class TestCargoesSuppliesGet:
+    """Тесты для метода cargoes_supplies_get."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_supplies_get(self, api, mock_api_request):
+        """Тестирует метод cargoes_supplies_get."""
+
+        mock_api_request.return_value = {
+            "not_found_supply_ids": [],
+            "supplies_cargoes": [
+                {
+                    "supply_id": 123,
+                    "bundle_id": "b-1",
+                    "cargoes_without_transport_cargoes": [
+                        {"cargo_id": 1, "barcode": "X", "bundle_id": "b-1"}
+                    ],
+                    "transport_cargoes": [
+                        {
+                            "transport_cargo_id": 10,
+                            "type": "PALLET",
+                            "bundle_id": "b-2",
+                            "cargoes": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        request = CargoesSuppliesGetRequest(supply_ids=["123"])
+
+        response = await api.cargoes_supplies_get(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/supplies/get",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesSuppliesGetResponse)
+        assert response.supplies_cargoes[0].supply_id == 123
+        assert response.supplies_cargoes[0].transport_cargoes[0].transport_cargo_id == 10

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_activate.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_activate.py
@@ -1,0 +1,32 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesTransportActivateRequest,
+    CargoesTransportActivateResponse,
+)
+
+
+class TestCargoesTransportActivate:
+    """Тесты для метода cargoes_transport_activate."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_transport_activate(self, api, mock_api_request):
+        """Тестирует метод cargoes_transport_activate."""
+
+        mock_api_request.return_value = {"operation_id": "op-ta-1"}
+
+        request = CargoesTransportActivateRequest(
+            supply_id=123, is_transport=True
+        )
+
+        response = await api.cargoes_transport_activate(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/activate",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesTransportActivateResponse)
+        assert response.operation_id == "op-ta-1"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_activate_status.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_activate_status.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesTransportActivateStatusRequest,
+    CargoesTransportActivateStatusResponse,
+)
+
+
+class TestCargoesTransportActivateStatus:
+    """Тесты для метода cargoes_transport_activate_status."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_transport_activate_status(self, api, mock_api_request):
+        """Тестирует метод cargoes_transport_activate_status."""
+
+        mock_api_request.return_value = {
+            "status": "IN_PROGRESS",
+            "error_reasons": [],
+        }
+
+        request = CargoesTransportActivateStatusRequest(operation_id="op-ta-1")
+
+        response = await api.cargoes_transport_activate_status(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/activate/status",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesTransportActivateStatusResponse)
+        assert response.status == "IN_PROGRESS"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_bind.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_bind.py
@@ -1,0 +1,39 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesTransportBindItem,
+    CargoesTransportBindRequest,
+    CargoesTransportBindResponse,
+)
+
+
+class TestCargoesTransportBind:
+    """Тесты для метода cargoes_transport_bind."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_transport_bind(self, api, mock_api_request):
+        """Тестирует метод cargoes_transport_bind."""
+
+        mock_api_request.return_value = {
+            "operation_id": "op-tb-1",
+            "error_reasons": [],
+        }
+
+        request = CargoesTransportBindRequest(
+            supply_id=123,
+            transport_cargo_bind=[
+                CargoesTransportBindItem(cargo_ids=["1"], transport_cargo_id=10)
+            ],
+        )
+
+        response = await api.cargoes_transport_bind(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/bind",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesTransportBindResponse)
+        assert response.operation_id == "op-tb-1"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_bind_status.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_bind_status.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesTransportBindStatusRequest,
+    CargoesTransportBindStatusResponse,
+)
+
+
+class TestCargoesTransportBindStatus:
+    """Тесты для метода cargoes_transport_bind_status."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_transport_bind_status(self, api, mock_api_request):
+        """Тестирует метод cargoes_transport_bind_status."""
+
+        mock_api_request.return_value = {
+            "status": "SUCCESS",
+            "error_reasons": [],
+        }
+
+        request = CargoesTransportBindStatusRequest(operation_id="op-tb-1")
+
+        response = await api.cargoes_transport_bind_status(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/bind/status",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesTransportBindStatusResponse)
+        assert response.status == "SUCCESS"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_create.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_create.py
@@ -1,0 +1,39 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesTransportCreateItem,
+    CargoesTransportCreateRequest,
+    CargoesTransportCreateResponse,
+)
+
+
+class TestCargoesTransportCreate:
+    """Тесты для метода cargoes_transport_create."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_transport_create(self, api, mock_api_request):
+        """Тестирует метод cargoes_transport_create."""
+
+        mock_api_request.return_value = {
+            "operation_id": "op-tc-1",
+            "error_reasons": [],
+        }
+
+        request = CargoesTransportCreateRequest(
+            supply_id=123,
+            transport_cargoes=[
+                CargoesTransportCreateItem(count=1, type="PALLET")
+            ],
+        )
+
+        response = await api.cargoes_transport_create(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/create",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesTransportCreateResponse)
+        assert response.operation_id == "op-tc-1"

--- a/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_create_status.py
+++ b/tests/test_methods/test_fbo_supply_request/test_cargoes_transport_create_status.py
@@ -1,0 +1,37 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo_supply_request import (
+    CargoesTransportCreateStatusRequest,
+    CargoesTransportCreateStatusResponse,
+)
+
+
+class TestCargoesTransportCreateStatus:
+    """Тесты для метода cargoes_transport_create_status."""
+
+    @pytest.mark.asyncio
+    async def test_cargoes_transport_create_status(self, api, mock_api_request):
+        """Тестирует метод cargoes_transport_create_status."""
+
+        mock_api_request.return_value = {
+            "status": "SUCCESS",
+            "error_reasons": [],
+            "result": {
+                "transport_cargoes": [{"id": 10, "type": "PALLET"}]
+            },
+        }
+
+        request = CargoesTransportCreateStatusRequest(operation_id="op-tc-1")
+
+        response = await api.cargoes_transport_create_status(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="cargoes/transport/create/status",
+            payload=request.model_dump(by_alias=True)
+        )
+
+        assert isinstance(response, CargoesTransportCreateStatusResponse)
+        assert response.status == "SUCCESS"
+        assert response.result.transport_cargoes[0].id == 10


### PR DESCRIPTION
## Что и зачем

Ozon добавил в live-спецификацию 14 новых операций с тегом **FBOTransport** (работа с
транспортными грузоместами FBO). Эта ветка реализует всю группу внутри `fbo_supply_request`.

### Новые методы (11 × v1 + 3 × v2 канонические)
- `/v1/cargoes/transport/create` + `/status`
- `/v1/cargoes/transport/activate` + `/status`
- `/v1/cargoes/transport/bind` + `/status`
- `/v1/cargoes/supplies/get`
- `/v1/cargoes/label/transport/create` + `/status`
- `/v1/cargoes/label/transport-by-order/create` + `/status`
- `/v2/cargoes/get`, `/v2/cargoes/delete`, `/v2/cargoes/delete/status` — канонические

### Коллизия версий (правило проекта: новее = канон без суффикса)
Старые v1-методы понижены до `*_v1()`:
- `cargoes_get()` → `cargoes_get_v1()` (канон = `/v2/cargoes/get`)
- `cargoes_delete()` → `cargoes_delete_v1()` (канон = `/v2/cargoes/delete`)
- `cargoes_delete_status()` → `cargoes_delete_status_v1()` (канон = `/v2/cargoes/delete/status`)

Миксины/методы/классы Request/Response старых версий получили инфикс `V1`; их README-строки
помечены `⚠️ устар. →`. Канонические v2-имена остаются без суффикса.

### Замечания по моделированию
Группа access-gated (FBOTransport), живой проверки нет — схемы строго по swagger,
response status/error-энумы как открытый `str`, тесты только на моках (`_request` мокируется).

## Версия
Бамп **0.85.1 → 0.86.0** (minor, новые методы) в `pyproject.toml` и `src/ozonapi/__init__.py`.

## Документация
README-каталог 447 → 461; секция «Создание и управление заявками на поставку FBO» 29 → 43;
добавлены 14 строк, 3 v1-строки помечены устаревшими. Счётчики пересчитаны из строк.

## Проверки
- `pytest`: **579 passed** (локально, транспорт мокируется — без сети).
- `mypy --config-file .claude/linters/mypy.ini`: чисто, 0 net new.
- Адверсариальное ревью (ozon-reviewer): без блокеров.

> ⚠️ Merge публикует 0.86.0 в PyPI — решение за человеком. Я (бот) PR не мержу.
