### PR TITLE
feat(fbo): add supply_order_timeslot_list — /v2/supply-order/timeslot/list (0.87.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ozonapi-async"
-version = "0.86.1"
+version = "0.87.0"
 description = "Асинхронный pydantic-интерфейс для Ozon Seller API c ограничением запросов и docstrings"
 readme = "readme.md"
 keywords = [

--- a/readme.md
+++ b/readme.md
@@ -410,7 +410,7 @@ pytest --cov=ozonapi --cov-report=html
 
 ## ✔️ Реализованные методы Ozon Seller API
 
-**Реализовано методов: 461 / 461**
+**Реализовано методов: 462 / 462**
 
 <details>
 <summary>Информация по API-ключу (1/1)</summary>
@@ -644,7 +644,7 @@ pytest --cov=ozonapi --cov-report=html
 | ✓ | `/v1/polygon/time/set` | Установить новое время доставки в полигоне | `polygon_time_set()` |
 </details>
 <details>
-<summary>Доставка FBO (15/15)</summary>
+<summary>Доставка FBO (16/16)</summary>
 
 | ✓ | Адрес метода Ozon | Описание метода | Python-метод |
 |---|---|---|---|
@@ -657,6 +657,7 @@ pytest --cov=ozonapi --cov-report=html
 | ✓ | `/v3/supply-order/list` | Список заявок на поставку на склад Ozon | `supply_order_list()` |
 | ✓ | `/v3/supply-order/get` | Информация о заявке на поставку | `supply_order_get()` |
 | ✓ | `/v1/supply-order/timeslot/get` | Интервалы поставки | `supply_order_timeslot_get()` |
+| ✓ | `/v2/supply-order/timeslot/list` | Список доступных интервалов поставки | `supply_order_timeslot_list()` |
 | ✓ | `/v1/supply-order/timeslot/update` | Обновить интервал поставки | `supply_order_timeslot_update()` |
 | ✓ | `/v1/supply-order/timeslot/status` | Статус интервала поставки | `supply_order_timeslot_status()` |
 | ✓ | `/v1/supply-order/pass/create` | Указать данные о водителе и автомобиле | `supply_order_pass_create()` |

--- a/src/ozonapi/__init__.py
+++ b/src/ozonapi/__init__.py
@@ -35,7 +35,7 @@ Examples:
 from .infrastructure import logging
 from .infrastructure.logging import ozonapi_logger as logger
 from .seller import SellerAPI, SellerAPIConfig
-__version__ = "0.86.1"
+__version__ = "0.87.0"
 __author__ = "Alexander Ulianov"
 __email__ = "a.v.ulianov@mail.ru"
 __repository__ = "https://github.com/a-ulianov/OzonAPI"

--- a/src/ozonapi/seller/methods/fbo/__init__.py
+++ b/src/ozonapi/seller/methods/fbo/__init__.py
@@ -17,6 +17,7 @@ from .supply_order_pass_create import SupplyOrderPassCreateMixin
 from .supply_order_pass_status import SupplyOrderPassStatusMixin
 from .supply_order_status_counter import SupplyOrderStatusCounterMixin
 from .supply_order_timeslot_get import SupplyOrderTimeslotGetMixin
+from .supply_order_timeslot_list import SupplyOrderTimeslotListMixin
 from .supply_order_timeslot_status import SupplyOrderTimeslotStatusMixin
 from .supply_order_timeslot_update import SupplyOrderTimeslotUpdateMixin
 
@@ -35,6 +36,7 @@ class SellerFBOAPI(
     SupplyOrderPassStatusMixin,
     SupplyOrderStatusCounterMixin,
     SupplyOrderTimeslotGetMixin,
+    SupplyOrderTimeslotListMixin,
     SupplyOrderTimeslotStatusMixin,
     SupplyOrderTimeslotUpdateMixin,
     APIManager,

--- a/src/ozonapi/seller/methods/fbo/supply_order_timeslot_list.py
+++ b/src/ozonapi/seller/methods/fbo/supply_order_timeslot_list.py
@@ -1,0 +1,41 @@
+from ...core import APIManager
+from ...schemas.fbo import SupplyOrderTimeslotListRequest, SupplyOrderTimeslotListResponse
+
+
+class SupplyOrderTimeslotListMixin(APIManager):
+    """Реализует метод /v2/supply-order/timeslot/list"""
+
+    async def supply_order_timeslot_list(
+            self: "SupplyOrderTimeslotListMixin",
+            request: SupplyOrderTimeslotListRequest
+    ) -> SupplyOrderTimeslotListResponse:
+        """Метод для получения списка доступных интервалов поставки заявки.
+
+        Notes:
+            • Возвращает список доступных интервалов поставки по местному времени склада.
+            • Дополнительно возвращает ограничения на изменение интервала и причины,
+              по которым изменить интервал нельзя.
+            • Выбранный интервал устанавливают методом `supply_order_timeslot_update`.
+
+        References:
+            https://docs.ozon.com/api/seller/?#operation/SupplyOrderTimeslotList
+
+        Args:
+            request: Запрос на получение интервалов поставки по схеме `SupplyOrderTimeslotListRequest`
+
+        Returns:
+            Доступные интервалы поставки по схеме `SupplyOrderTimeslotListResponse`
+
+        Example:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.supply_order_timeslot_list(
+                    SupplyOrderTimeslotListRequest(order_id=1234567890)
+                )
+        """
+        response = await self._request(
+            method="post",
+            api_version="v2",
+            endpoint="supply-order/timeslot/list",
+            payload=request.model_dump(by_alias=True)
+        )
+        return SupplyOrderTimeslotListResponse(**response)

--- a/src/ozonapi/seller/schemas/fbo/__init__.py
+++ b/src/ozonapi/seller/schemas/fbo/__init__.py
@@ -34,6 +34,13 @@ __all__ = [
     "SupplyOrderTimeslotUpdateResponse",
     "SupplyOrderTimeslotStatusRequest",
     "SupplyOrderTimeslotStatusResponse",
+    "SupplyOrderTimeslotListRequest",
+    "SupplyOrderTimeslotListResponse",
+    "SupplyOrderTimeslotListLimitExceeded",
+    "SupplyOrderTimeslotListChangeForbidden",
+    "SupplyOrderTimeslotListLimitations",
+    "SupplyOrderTimeslotListTimezone",
+    "SupplyOrderTimeslotListTimeslotsInfo",
     "SupplyOrderPassCreateRequest",
     "SupplyOrderVehicleInfo",
     "SupplyOrderPassCreateResponse",
@@ -79,6 +86,15 @@ from .v1__supply_order_timeslot_update import (
 from .v1__supply_order_timeslot_status import (
     SupplyOrderTimeslotStatusRequest,
     SupplyOrderTimeslotStatusResponse,
+)
+from .v2__supply_order_timeslot_list import (
+    SupplyOrderTimeslotListChangeForbidden,
+    SupplyOrderTimeslotListLimitExceeded,
+    SupplyOrderTimeslotListLimitations,
+    SupplyOrderTimeslotListRequest,
+    SupplyOrderTimeslotListResponse,
+    SupplyOrderTimeslotListTimeslotsInfo,
+    SupplyOrderTimeslotListTimezone,
 )
 from .v1__supply_order_pass_create import (
     SupplyOrderPassCreateRequest,

--- a/src/ozonapi/seller/schemas/fbo/v2__supply_order_timeslot_list.py
+++ b/src/ozonapi/seller/schemas/fbo/v2__supply_order_timeslot_list.py
@@ -1,0 +1,114 @@
+"""https://docs.ozon.com/api/seller/?#operation/SupplyOrderTimeslotList"""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from .entities import SupplyOrderTimeslot
+
+
+class SupplyOrderTimeslotListLimitExceeded(BaseModel):
+    """Описывает информацию о превышении лимита изменений интервала поставки.
+
+    Attributes:
+        changes_limit: Остаток доступных изменений интервала поставки
+    """
+    changes_limit: Optional[int] = Field(
+        None, description="Остаток доступных изменений интервала поставки."
+    )
+
+
+class SupplyOrderTimeslotListChangeForbidden(BaseModel):
+    """Описывает причины, по которым нельзя изменить интервал поставки.
+
+    Attributes:
+        error_reasons: Причины запрета изменения интервала поставки (строками)
+    """
+    error_reasons: Optional[list[str]] = Field(
+        default_factory=list,
+        description=(
+            "Причины, по которым нельзя изменить интервал поставки: "
+            "`INVALID_ORDER_STATE` — неверный статус заявки на поставку; "
+            "`IS_VIRTUAL` — заявка на поставку виртуальная; "
+            "`SET_TIMESLOT_DEADLINE_EXCEED` — заявка на поставку просрочена; "
+            "`ORDER_DOES_NOT_BELONG_TO_COMPANY` — заявка на поставку не принадлежит продавцу."
+        ),
+    )
+
+
+class SupplyOrderTimeslotListLimitations(BaseModel):
+    """Описывает ограничения на обновления интервала поставки.
+
+    Attributes:
+        changes_count: Количество изменений интервала поставки
+        changes_limit: Остаток доступных изменений интервала поставки
+    """
+    changes_count: Optional[int] = Field(
+        None, description="Количество изменений интервала поставки."
+    )
+    changes_limit: Optional[int] = Field(
+        None, description="Остаток доступных изменений интервала поставки."
+    )
+
+
+class SupplyOrderTimeslotListTimezone(BaseModel):
+    """Описывает часовой пояс интервалов поставки.
+
+    Attributes:
+        iana_name: Название часового пояса (IANA)
+        offset: Смещение часового пояса от UTC-0 в секундах
+    """
+    iana_name: Optional[str] = Field(
+        None, description="Название часового пояса."
+    )
+    offset: Optional[int] = Field(
+        None, description="Смещение часового пояса от UTC-0 в секундах."
+    )
+
+
+class SupplyOrderTimeslotListTimeslotsInfo(BaseModel):
+    """Описывает информацию об интервалах поставки.
+
+    Attributes:
+        limitations: Ограничения на обновления интервала поставки
+        timeslots: Список интервалов поставки
+        timezone: Часовой пояс интервалов
+    """
+    limitations: Optional[SupplyOrderTimeslotListLimitations] = Field(
+        None, description="Ограничения на обновления интервала поставки."
+    )
+    timeslots: Optional[list[SupplyOrderTimeslot]] = Field(
+        default_factory=list, description="Список интервалов поставки."
+    )
+    timezone: Optional[SupplyOrderTimeslotListTimezone] = Field(
+        None, description="Часовой пояс интервалов."
+    )
+
+
+class SupplyOrderTimeslotListRequest(BaseModel):
+    """Описывает схему запроса на получение списка доступных интервалов поставки.
+
+    Attributes:
+        order_id: Идентификатор заявки на поставку
+    """
+    order_id: int = Field(
+        ..., description="Идентификатор заявки на поставку."
+    )
+
+
+class SupplyOrderTimeslotListResponse(BaseModel):
+    """Описывает схему ответа на запрос списка доступных интервалов поставки.
+
+    Attributes:
+        limit_exceeded: Информация о превышении лимита изменений интервала поставки
+        timeslot_change_forbidden: Информация о причинах запрета изменения интервала поставки
+        timeslots_info: Информация об интервалах поставки
+    """
+    limit_exceeded: Optional[SupplyOrderTimeslotListLimitExceeded] = Field(
+        None, description="Информация о превышении лимита изменений интервала поставки."
+    )
+    timeslot_change_forbidden: Optional[SupplyOrderTimeslotListChangeForbidden] = Field(
+        None, description="Информация о причинах, по которым нельзя изменить интервал поставки."
+    )
+    timeslots_info: Optional[SupplyOrderTimeslotListTimeslotsInfo] = Field(
+        None, description="Информация об интервалах поставки."
+    )

--- a/tests/test_methods/test_fbo/test_supply_order_timeslot_list.py
+++ b/tests/test_methods/test_fbo/test_supply_order_timeslot_list.py
@@ -1,0 +1,51 @@
+import pytest
+
+from src.ozonapi.seller.schemas.fbo import (
+    SupplyOrderTimeslotListRequest,
+    SupplyOrderTimeslotListResponse,
+)
+
+
+class TestSupplyOrderTimeslotList:
+    """Тесты для метода supply_order_timeslot_list."""
+
+    @pytest.mark.asyncio
+    async def test_supply_order_timeslot_list(self, api, mock_api_request):
+        """Тестирует метод supply_order_timeslot_list."""
+
+        mock_response_data = {
+            "limit_exceeded": {"changes_limit": 3},
+            "timeslot_change_forbidden": {
+                "error_reasons": ["INVALID_ORDER_STATE"],
+            },
+            "timeslots_info": {
+                "limitations": {"changes_count": 1, "changes_limit": 3},
+                "timeslots": [
+                    {"from": "2026-06-01T10:00:00Z", "to": "2026-06-01T12:00:00Z"},
+                    {"from": "2026-06-01T12:00:00Z", "to": "2026-06-01T14:00:00Z"},
+                ],
+                "timezone": {"iana_name": "Europe/Moscow", "offset": 10800},
+            },
+        }
+        mock_api_request.return_value = mock_response_data
+
+        request = SupplyOrderTimeslotListRequest(order_id=1234567890)
+
+        response = await api.supply_order_timeslot_list(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v2",
+            endpoint="supply-order/timeslot/list",
+            payload=request.model_dump(by_alias=True),
+        )
+
+        assert isinstance(response, SupplyOrderTimeslotListResponse)
+        assert response.limit_exceeded.changes_limit == 3
+        assert response.timeslot_change_forbidden.error_reasons == ["INVALID_ORDER_STATE"]
+        assert response.timeslots_info.limitations.changes_count == 1
+        assert len(response.timeslots_info.timeslots) == 2
+        assert response.timeslots_info.timeslots[0].from_ is not None
+        assert response.timeslots_info.timeslots[0].to is not None
+        assert response.timeslots_info.timezone.iana_name == "Europe/Moscow"
+        assert response.timeslots_info.timezone.offset == 10800


### PR DESCRIPTION
## Что
Новый метод `supply_order_timeslot_list` для операции
`POST /v2/supply-order/timeslot/list` (tag `BetaMethod`), которую Ozon
добавил в OpenAPI-спецификацию (swagger-дельта +1).

Возвращает список доступных интервалов поставки заявки вместе с:
- `limit_exceeded` — остаток доступных изменений интервала;
- `timeslot_change_forbidden.error_reasons` — причины запрета изменения
  интервала (открытый список `str`);
- `timeslots_info` — `limitations` (count/limit), `timeslots`
  (переиспользуется entity `SupplyOrderTimeslot`), `timezone`
  (iana_name + offset в секундах, `int`).

## Почему
Поддержание актуальности с API Ozon: новая операция в live-спецификации.
Это `list`-действие, отдельное от уже реализованного `v1 .../timeslot/get`
— коллизии версий нет.

## Детали
- Группа `fbo`, схема `v2__supply_order_timeslot_list.py`, миксин
  `SupplyOrderTimeslotListMixin`, wiring в обоих `__init__`.
- Access-gated/beta → схема строго по swagger, response enum = открытый
  `str`, тест только на моках (транспорт замокан, без сети).
- README: новая строка каталога, секция «Доставка FBO» 15→16, общий
  счётчик 461→462.

## Версия
0.86.1 → **0.87.0** (minor — новый метод), в `pyproject.toml` и
`src/ozonapi/__init__.py`.

## Гейт
- `pytest: 580 passed` (локально, транспорт замокан).
- mypy (`--config-file .claude/linters/mypy.ini`): 0 net-new ошибок.
- CI branch run: см. статус этого PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
