### PR TITLE
feat(warehouses): add is_courier_phone_same_as_warehouse to erfbs aggregator delivery-method/update (0.88.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ozonapi-async"
-version = "0.87.0"
+version = "0.88.0"
 description = "Асинхронный pydantic-интерфейс для Ozon Seller API c ограничением запросов и docstrings"
 readme = "readme.md"
 keywords = [

--- a/src/ozonapi/__init__.py
+++ b/src/ozonapi/__init__.py
@@ -35,7 +35,7 @@ Examples:
 from .infrastructure import logging
 from .infrastructure.logging import ozonapi_logger as logger
 from .seller import SellerAPI, SellerAPIConfig
-__version__ = "0.87.0"
+__version__ = "0.88.0"
 __author__ = "Alexander Ulianov"
 __email__ = "a.v.ulianov@mail.ru"
 __repository__ = "https://github.com/a-ulianov/OzonAPI"

--- a/src/ozonapi/seller/schemas/warehouses/v1__warehouse_erfbs_aggregator_delivery_method_update.py
+++ b/src/ozonapi/seller/schemas/warehouses/v1__warehouse_erfbs_aggregator_delivery_method_update.py
@@ -16,6 +16,7 @@ class WarehouseERFBSAggregatorDeliveryMethodUpdateRequest(BaseModel):
         deliver_to_pvz: Доставлять в пункт выдачи
         delivery_costs: Стоимость доставки
         delivery_method_id: Идентификатор метода доставки
+        is_courier_phone_same_as_warehouse: Совпадает ли телефон курьера с телефоном склада
         name: Название метода доставки
         return_settings: Настройки возврата
         warehouse_id: Идентификатор склада
@@ -36,6 +37,9 @@ class WarehouseERFBSAggregatorDeliveryMethodUpdateRequest(BaseModel):
     )
     delivery_method_id: Optional[int] = Field(
         None, description="Идентификатор метода доставки."
+    )
+    is_courier_phone_same_as_warehouse: Optional[bool] = Field(
+        None, description="Совпадает ли телефон курьера с телефоном склада."
     )
     name: Optional[str] = Field(None, description="Название метода доставки.")
     return_settings: Optional[WarehouseERFBSReturnSettings] = Field(

--- a/tests/test_methods/test_warehouses/test_warehouse_erfbs_aggregator_delivery_method_update.py
+++ b/tests/test_methods/test_warehouses/test_warehouse_erfbs_aggregator_delivery_method_update.py
@@ -21,6 +21,7 @@ class TestWarehouseERFBSAggregatorDeliveryMethodUpdate:
             name="Партнёры Ozon",
             cut_in=120,
             deliver_to_pvz=False,
+            is_courier_phone_same_as_warehouse=True,
             return_settings={"return_method": "TRANSPORT_COMPANY", "transport_company_name": "СДЭК"},
         )
 


### PR DESCRIPTION
## Что изменилось
Ozon добавил в спецификацию Request операции `POST /v1/warehouse/erfbs/aggregator/delivery-method/update`
новое опциональное поле `is_courier_phone_same_as_warehouse` (`boolean`) — совпадает ли телефон
курьера с телефоном склада.

Изменение аддитивное и не ломающее: поле добавлено в
`WarehouseERFBSAggregatorDeliveryMethodUpdateRequest`
(`v1__warehouse_erfbs_aggregator_delivery_method_update.py`) с русским `Field(description=...)` и
записью в блоке `Attributes:`. Тест метода дополнен передачей нового поля.

## Почему
Синхронизация со свежей live-спецификацией Ozon Seller API (swagger-дельта `~1`, сигнал watcher от
2026-07-01). Метод уже реализован — строка каталога README остаётся `✓`, счётчики методов без
изменений.

## Версия
Минорный бамп `0.87.0 → 0.88.0` в `pyproject.toml` и `src/ozonapi/__init__.py` (прецедент: PR #4 —
добавление поля в существующий метод минорным бампом). Публикация в PyPI произойдёт только при merge
человеком.

## Проверки
- `pytest: 580 passed`
- mypy (`--config-file .claude/linters/mypy.ini`): чисто на изменённой схеме, 0 net-new ошибок
- CI ветки: см. статус ниже

🤖 Generated with [Claude Code](https://claude.com/claude-code)
