### PR TITLE
feat(fbp): add posting_fbp_get — /v1/posting/fbp/get (0.89.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ozonapi-async"
-version = "0.88.0"
+version = "0.89.0"
 description = "Асинхронный pydantic-интерфейс для Ozon Seller API c ограничением запросов и docstrings"
 readme = "readme.md"
 keywords = [

--- a/readme.md
+++ b/readme.md
@@ -410,7 +410,7 @@ pytest --cov=ozonapi --cov-report=html
 
 ## ✔️ Реализованные методы Ozon Seller API
 
-**Реализовано методов: 462 / 462**
+**Реализовано методов: 463 / 463**
 
 <details>
 <summary>Информация по API-ключу (1/1)</summary>
@@ -1114,7 +1114,7 @@ pytest --cov=ozonapi --cov-report=html
 | ✓ | `/v1/fbp/order/pick-up/dlv/edit` | Изменить данные о точке забора | `fbp_order_pick_up_dlv_edit()` |
 </details>
 <details>
-<summary>Работа с созданной поставкой FBP (11/11)</summary>
+<summary>Работа с созданной поставкой FBP (12/12)</summary>
 
 | ✓ | Адрес метода Ozon | Описание метода | Python-метод |
 |---|---|---|---|
@@ -1128,6 +1128,7 @@ pytest --cov=ozonapi --cov-report=html
 | ✓ | `/v1/fbp/label/get` | Получить статус задания на генерацию этикеток | `fbp_label_get()` |
 | ✓ | `/v1/fbp/order/get` | Получить информацию о конкретной поставке | `fbp_order_get()` |
 | ✓ | `/v1/fbp/order/list` | Получить список поставок | `fbp_order_list()` |
+| ✓ | `/v1/posting/fbp/get` | Получить информацию об отправлении | `posting_fbp_get()` |
 | ✓ | `/v1/posting/fbp/list` | Получить список отправлений | `posting_fbp_list()` |
 </details>
 <details>

--- a/src/ozonapi/__init__.py
+++ b/src/ozonapi/__init__.py
@@ -35,7 +35,7 @@ Examples:
 from .infrastructure import logging
 from .infrastructure.logging import ozonapi_logger as logger
 from .seller import SellerAPI, SellerAPIConfig
-__version__ = "0.88.0"
+__version__ = "0.89.0"
 __author__ = "Alexander Ulianov"
 __email__ = "a.v.ulianov@mail.ru"
 __repository__ = "https://github.com/a-ulianov/OzonAPI"

--- a/src/ozonapi/seller/methods/fbp/__init__.py
+++ b/src/ozonapi/seller/methods/fbp/__init__.py
@@ -45,6 +45,7 @@ from .fbp_act_to_create import FbpActToCreateMixin
 from .fbp_act_to_get import FbpActToGetMixin
 from .fbp_label_create import FbpLabelCreateMixin
 from .fbp_label_get import FbpLabelGetMixin
+from .posting_fbp_get import PostingFbpGetMixin
 from .posting_fbp_list import PostingFbpListMixin
 
 
@@ -94,6 +95,7 @@ class SellerFbpAPI(
     FbpActToGetMixin,
     FbpLabelCreateMixin,
     FbpLabelGetMixin,
+    PostingFbpGetMixin,
     PostingFbpListMixin,
 ):
     """Реализует методы раздела FBP (черновики и поставки).

--- a/src/ozonapi/seller/methods/fbp/posting_fbp_get.py
+++ b/src/ozonapi/seller/methods/fbp/posting_fbp_get.py
@@ -1,0 +1,43 @@
+from ...core import APIManager
+from ...schemas.fbp import PostingFbpGetRequest, PostingFbpGetResponse
+
+
+class PostingFbpGetMixin(APIManager):
+    """Реализует метод /v1/posting/fbp/get"""
+
+    async def posting_fbp_get(
+            self: "PostingFbpGetMixin",
+            request: PostingFbpGetRequest,
+    ) -> PostingFbpGetResponse:
+        """Получает информацию об отправлении FBP по идентификатору.
+
+        Notes:
+            • Возвращает детальную информацию об одном отправлении по его номеру:
+              аналитические и финансовые данные, состав товаров, статус и отмену.
+            • Даты в ответе (`in_process_at`, `order_date`, `analytics_data.*`)
+              приходят строками в формате RFC3339.
+
+        References:
+            https://docs.ozon.ru/api/seller/?#operation/PostingAPI_GetFbpPosting
+
+        Args:
+            request: Номер отправления по схеме `PostingFbpGetRequest`
+
+        Returns:
+            Информация об отправлении по схеме `PostingFbpGetResponse`
+
+        Example:
+            async with SellerAPI(client_id, api_key) as api:
+                result = await api.posting_fbp_get(
+                    PostingFbpGetRequest(posting_number="P-1")
+                )
+
+            print(result.posting.status, result.posting.posting_number)
+        """
+        response = await self._request(
+            method="post",
+            api_version="v1",
+            endpoint="posting/fbp/get",
+            payload=request.model_dump(),
+        )
+        return PostingFbpGetResponse(**response)

--- a/src/ozonapi/seller/schemas/fbp/__init__.py
+++ b/src/ozonapi/seller/schemas/fbp/__init__.py
@@ -141,6 +141,17 @@ __all__ = [
     "PostingFbpFinancialData",
     "PostingFbp",
     "PostingFbpListResponse",
+    "PostingFbpGetRequest",
+    "PostingFbpGetMoney",
+    "PostingFbpGetAnalyticsData",
+    "PostingFbpGetCancellation",
+    "PostingFbpGetFinancialAction",
+    "PostingFbpGetCommission",
+    "PostingFbpGetFinancialProduct",
+    "PostingFbpGetFinancialData",
+    "PostingFbpGetProduct",
+    "PostingFbpGetPosting",
+    "PostingFbpGetResponse",
 ]
 
 from .base import FbpDraftCreateResult, FbpOrderValidationResult
@@ -372,4 +383,17 @@ from .v1__posting_fbp_list import (
     PostingFbpListResponse,
     PostingFbpMoney,
     PostingFbpProduct,
+)
+from .v1__posting_fbp_get import (
+    PostingFbpGetAnalyticsData,
+    PostingFbpGetCancellation,
+    PostingFbpGetCommission,
+    PostingFbpGetFinancialAction,
+    PostingFbpGetFinancialData,
+    PostingFbpGetFinancialProduct,
+    PostingFbpGetMoney,
+    PostingFbpGetPosting,
+    PostingFbpGetProduct,
+    PostingFbpGetRequest,
+    PostingFbpGetResponse,
 )

--- a/src/ozonapi/seller/schemas/fbp/v1__posting_fbp_get.py
+++ b/src/ozonapi/seller/schemas/fbp/v1__posting_fbp_get.py
@@ -1,0 +1,264 @@
+"""https://docs.ozon.ru/api/seller/#operation/PostingAPI_GetFbpPosting"""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class PostingFbpGetRequest(BaseModel):
+    """Схема запроса информации об отправлении FBP.
+
+    Attributes:
+        posting_number: Номер отправления
+    """
+
+    posting_number: str = Field(..., description="Номер отправления.")
+
+
+class PostingFbpGetMoney(BaseModel):
+    """Денежная сумма отправления FBP.
+
+    Attributes:
+        amount: Сумма (строка)
+        currency: Код валюты
+    """
+
+    amount: Optional[str] = Field(None, description="Сумма (строка).")
+    currency: Optional[str] = Field(None, description="Код валюты.")
+
+
+class PostingFbpGetAnalyticsData(BaseModel):
+    """Аналитические данные отправления FBP.
+
+    Attributes:
+        city: Город доставки
+        delivery_date_begin: Начало периода доставки
+        delivery_date_end: Конец периода доставки
+        delivery_type: Тип доставки
+        region: Регион доставки
+        warehouse_id: Идентификатор склада
+    """
+
+    city: Optional[str] = Field(None, description="Город доставки.")
+    delivery_date_begin: Optional[str] = Field(
+        None, description="Начало периода доставки в формате RFC3339."
+    )
+    delivery_date_end: Optional[str] = Field(
+        None, description="Конец периода доставки в формате RFC3339."
+    )
+    delivery_type: Optional[str] = Field(None, description="Тип доставки.")
+    region: Optional[str] = Field(None, description="Регион доставки.")
+    warehouse_id: Optional[int] = Field(None, description="Идентификатор склада.")
+
+
+class PostingFbpGetCancellation(BaseModel):
+    """Информация об отмене отправления FBP.
+
+    Attributes:
+        cancel_reason: Причина отмены
+        cancel_reason_id: Идентификатор причины отмены
+        cancellation_initiator: Инициатор отмены
+        cancellation_type: Тип отмены
+    """
+
+    cancel_reason: Optional[str] = Field(None, description="Причина отмены.")
+    cancel_reason_id: Optional[int] = Field(
+        None, description="Идентификатор причины отмены."
+    )
+    cancellation_initiator: Optional[str] = Field(
+        None, description="Инициатор отмены."
+    )
+    cancellation_type: Optional[str] = Field(None, description="Тип отмены.")
+
+
+class PostingFbpGetFinancialAction(BaseModel):
+    """Акция, применённая к товару отправления FBP.
+
+    Attributes:
+        action_id: Идентификатор акции
+        action_type: Тип акции
+        date_from: Начало действия акции
+        date_to: Конец действия акции
+        description: Описание акции
+        discount_percent: Процент скидки
+        discount_value: Размер скидки
+    """
+
+    action_id: Optional[int] = Field(None, description="Идентификатор акции.")
+    action_type: Optional[str] = Field(None, description="Тип акции.")
+    date_from: Optional[str] = Field(
+        None, description="Начало действия акции в формате RFC3339."
+    )
+    date_to: Optional[str] = Field(
+        None, description="Конец действия акции в формате RFC3339."
+    )
+    description: Optional[str] = Field(None, description="Описание акции.")
+    discount_percent: Optional[float] = Field(None, description="Процент скидки.")
+    discount_value: Optional[float] = Field(None, description="Размер скидки.")
+
+
+class PostingFbpGetCommission(BaseModel):
+    """Комиссия по товару отправления FBP.
+
+    Attributes:
+        amount: Сумма комиссии
+        payout: Выплата
+        percent: Процент комиссии
+    """
+
+    amount: Optional[float] = Field(None, description="Сумма комиссии.")
+    payout: Optional[float] = Field(None, description="Выплата.")
+    percent: Optional[float] = Field(None, description="Процент комиссии.")
+
+
+class PostingFbpGetFinancialProduct(BaseModel):
+    """Финансовые данные по товару отправления FBP.
+
+    Attributes:
+        actions: Применённые к товару акции
+        commissions_price: Цена комиссий
+        customer_price: Цена для покупателя
+        old_price: Цена до скидок
+        posting_commission: Комиссия за отправление
+        quantity: Количество товара
+        return_commission: Комиссия за возврат
+        seller_price: Цена продавца
+        sku: Идентификатор товара в системе Ozon — SKU
+        total_discount_percent: Суммарный процент скидки
+        total_discount_value: Суммарный размер скидки
+    """
+
+    actions: list[PostingFbpGetFinancialAction] = Field(
+        default_factory=list, description="Применённые к товару акции."
+    )
+    commissions_price: Optional[PostingFbpGetMoney] = Field(
+        None, description="Цена комиссий."
+    )
+    customer_price: Optional[PostingFbpGetMoney] = Field(
+        None, description="Цена для покупателя."
+    )
+    old_price: Optional[float] = Field(None, description="Цена до скидок.")
+    posting_commission: Optional[PostingFbpGetCommission] = Field(
+        None, description="Комиссия за отправление."
+    )
+    quantity: Optional[int] = Field(None, description="Количество товара.")
+    return_commission: Optional[PostingFbpGetCommission] = Field(
+        None, description="Комиссия за возврат."
+    )
+    seller_price: Optional[PostingFbpGetMoney] = Field(
+        None, description="Цена продавца."
+    )
+    sku: Optional[int] = Field(
+        None, description="Идентификатор товара в системе Ozon — SKU."
+    )
+    total_discount_percent: Optional[float] = Field(
+        None, description="Суммарный процент скидки."
+    )
+    total_discount_value: Optional[float] = Field(
+        None, description="Суммарный размер скидки."
+    )
+
+
+class PostingFbpGetFinancialData(BaseModel):
+    """Финансовые данные отправления FBP.
+
+    Attributes:
+        cluster_from: Кластер отправления
+        cluster_to: Кластер назначения
+        delivery_amount: Стоимость доставки
+        products: Финансовые данные по товарам
+    """
+
+    cluster_from: Optional[str] = Field(None, description="Кластер отправления.")
+    cluster_to: Optional[str] = Field(None, description="Кластер назначения.")
+    delivery_amount: Optional[float] = Field(None, description="Стоимость доставки.")
+    products: list[PostingFbpGetFinancialProduct] = Field(
+        default_factory=list, description="Финансовые данные по товарам."
+    )
+
+
+class PostingFbpGetProduct(BaseModel):
+    """Товар отправления FBP.
+
+    Attributes:
+        has_imei: Признак наличия IMEI
+        marketplace_seller_price: Цена продавца на площадке
+        name: Название товара
+        offer_id: Артикул товара в системе продавца
+        quantity: Количество товара
+        sku: Идентификатор товара в системе Ozon — SKU
+        weight_max: Максимальный вес товара
+    """
+
+    has_imei: Optional[bool] = Field(None, description="Признак наличия IMEI.")
+    marketplace_seller_price: Optional[PostingFbpGetMoney] = Field(
+        None, description="Цена продавца на площадке."
+    )
+    name: Optional[str] = Field(None, description="Название товара.")
+    offer_id: Optional[str] = Field(
+        None, description="Артикул товара в системе продавца."
+    )
+    quantity: Optional[int] = Field(None, description="Количество товара.")
+    sku: Optional[int] = Field(
+        None, description="Идентификатор товара в системе Ozon — SKU."
+    )
+    weight_max: Optional[float] = Field(None, description="Максимальный вес товара.")
+
+
+class PostingFbpGetPosting(BaseModel):
+    """Отправление FBP.
+
+    Attributes:
+        analytics_data: Аналитические данные
+        cancellation: Информация об отмене
+        financial_data: Финансовые данные
+        in_process_at: Дата перехода в обработку
+        order_date: Дата заказа
+        order_id: Идентификатор заказа
+        order_number: Номер заказа
+        posting_number: Номер отправления
+        products: Товары отправления
+        status: Статус отправления
+        substatus: Подстатус отправления
+        tpl_provider_id: Идентификатор провайдера доставки
+    """
+
+    analytics_data: Optional[PostingFbpGetAnalyticsData] = Field(
+        None, description="Аналитические данные."
+    )
+    cancellation: Optional[PostingFbpGetCancellation] = Field(
+        None, description="Информация об отмене."
+    )
+    financial_data: Optional[PostingFbpGetFinancialData] = Field(
+        None, description="Финансовые данные."
+    )
+    in_process_at: Optional[str] = Field(
+        None, description="Дата перехода в обработку в формате RFC3339."
+    )
+    order_date: Optional[str] = Field(
+        None, description="Дата заказа в формате RFC3339."
+    )
+    order_id: Optional[int] = Field(None, description="Идентификатор заказа.")
+    order_number: Optional[str] = Field(None, description="Номер заказа.")
+    posting_number: Optional[str] = Field(None, description="Номер отправления.")
+    products: list[PostingFbpGetProduct] = Field(
+        default_factory=list, description="Товары отправления."
+    )
+    status: Optional[int] = Field(
+        None, description="Статус отправления (числовой код)."
+    )
+    substatus: Optional[str] = Field(None, description="Подстатус отправления.")
+    tpl_provider_id: Optional[int] = Field(
+        None, description="Идентификатор провайдера доставки."
+    )
+
+
+class PostingFbpGetResponse(BaseModel):
+    """Схема ответа с информацией об отправлении FBP.
+
+    Attributes:
+        posting: Данные отправления
+    """
+
+    posting: Optional[PostingFbpGetPosting] = Field(
+        None, description="Данные отправления."
+    )

--- a/tests/test_methods/test_fbp/test_fbp_supply.py
+++ b/tests/test_methods/test_fbp/test_fbp_supply.py
@@ -21,6 +21,8 @@ from src.ozonapi.seller.schemas.fbp import (
     FbpOrderGetResponse,
     FbpOrderListRequest,
     FbpOrderListResponse,
+    PostingFbpGetRequest,
+    PostingFbpGetResponse,
     PostingFbpListFilter,
     PostingFbpListRequest,
     PostingFbpListResponse,
@@ -312,3 +314,62 @@ class TestPostingFbpList:
         assert response.postings[0].posting_number == "P-1"
         assert response.postings[0].products[0].price.amount == "100.00"
         assert response.postings[0].financial_data.products[0].actions[0].action_id == "a1"
+
+
+class TestPostingFbpGet:
+    """Тесты для метода posting_fbp_get."""
+
+    @pytest.mark.asyncio
+    async def test_posting_fbp_get(self, api, mock_api_request):
+        """Тестирует метод posting_fbp_get."""
+        mock_api_request.return_value = {
+            "posting": {
+                "posting_number": "P-1",
+                "order_id": 12345,
+                "order_number": "O-1",
+                "status": 3,
+                "substatus": "posting_transferred_to_delivery",
+                "tpl_provider_id": 24,
+                "analytics_data": {"city": "Москва", "warehouse_id": 42},
+                "cancellation": {"cancel_reason_id": 0, "cancel_reason": ""},
+                "products": [
+                    {
+                        "sku": 123,
+                        "name": "Товар",
+                        "offer_id": "art-1",
+                        "quantity": 2,
+                        "has_imei": False,
+                        "marketplace_seller_price": {"amount": "100.00", "currency": "RUB"},
+                    }
+                ],
+                "financial_data": {
+                    "delivery_amount": 50.0,
+                    "products": [
+                        {
+                            "sku": 123,
+                            "quantity": 2,
+                            "old_price": 120.0,
+                            "commissions_price": {"amount": "10.00", "currency": "RUB"},
+                            "posting_commission": {"amount": 10.0, "payout": 90.0, "percent": 10.0},
+                            "actions": [{"action_id": 1, "discount_value": 20.0}],
+                        }
+                    ],
+                },
+            }
+        }
+
+        request = PostingFbpGetRequest(posting_number="P-1")
+        response = await api.posting_fbp_get(request)
+
+        mock_api_request.assert_called_once_with(
+            method="post",
+            api_version="v1",
+            endpoint="posting/fbp/get",
+            payload=request.model_dump(),
+        )
+        assert isinstance(response, PostingFbpGetResponse)
+        assert response.posting.posting_number == "P-1"
+        assert response.posting.status == 3
+        assert response.posting.products[0].marketplace_seller_price.amount == "100.00"
+        assert response.posting.financial_data.products[0].posting_commission.payout == 90.0
+        assert response.posting.financial_data.products[0].actions[0].action_id == 1


### PR DESCRIPTION
## Что изменилось
Добавлен новый метод `posting_fbp_get` в группе `fbp` — обёртка над операцией
`POST /v1/posting/fbp/get` (tag `BetaMethod`): получение информации об одном
отправлении FBP по его номеру.

## Почему
Дневной watcher-коллектор зафиксировал в live-спецификации Ozon Seller API новую
операцию `POST /v1/posting/fbp/get` (swagger-дельта `+1`). Метод отсутствовал в
библиотеке (`grep` по `posting/fbp/get` — пусто; реализован был только
`posting_fbp_list`). Это `get`-действие, отдельное от `list` → коллизии версий/имён нет.

## Детали реализации
- `schemas/fbp/v1__posting_fbp_get.py`: `PostingFbpGetRequest` (`posting_number`) +
  `PostingFbpGetResponse` с вложенным `posting{analytics_data, cancellation,
  financial_data, products, status, substatus, tpl_provider_id}`. Схема отдельная
  от `posting_fbp_list` — набор полей у `get` богаче (substatus, tpl_provider_id,
  has_imei, marketplace_seller_price, posting/return commission).
- Метод access-gated (весь блок FBP отдаёт `Error 7`), live-верификация невозможна →
  модель строго по swagger, тесты только на моках (транспорт замокан, сеть не трогаем).
- `methods/fbp/posting_fbp_get.py`: `PostingFbpGetMixin`; wiring в `__init__` группы `fbp`.
- Тест `TestPostingFbpGet` в `test_fbp_supply.py`.

## Документация
- `readme.md`: новая строка каталога `/v1/posting/fbp/get`; секция «Работа с созданной
  поставкой FBP» 11→12; общий счётчик **462 → 463**.

## Версия
`0.88.0 → 0.89.0` (minor — новый метод), в `pyproject.toml` и `src/ozonapi/__init__.py`.

## Проверки
- `pytest: 581 passed` (локально, транспорт замокан).
- `mypy --config-file .claude/linters/mypy.ini`: 0 net-new ошибок.
- Ветка `feat/posting-fbp-get`, CI ожидается зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
